### PR TITLE
check for empty revisions list

### DIFF
--- a/scripts/update-tool.py
+++ b/scripts/update-tool.py
@@ -20,7 +20,7 @@ def update_file(fn, owner=None, name=None, without=False):
         logging.debug("Examining {owner}/{name}".format(**tool))
 
         if without:
-            if 'revisions' in tool:
+            if 'revisions' in tool and not len(tool.get('revisions', [])) == 0:
                 continue
 
         if not without and owner and tool['owner'] != owner:


### PR DESCRIPTION
After running scripts/fix-lockfile.py some tool entries were listed with revisions: [] and were not picked up when using --without option