### PR TITLE
Add velvet from toolshed

### DIFF
--- a/training.yaml
+++ b/training.yaml
@@ -7,3 +7,6 @@ tools:
   - name: velvetoptimiser
     owner: simon-gladman
     tool_panel_section_label: Assembly
+  - name: velvet
+    owner: devteam
+    tool_panel_section_label: Assembly


### PR DESCRIPTION
There are already some velvet tools in usegalaxy.eu, but they are not up-to-date with the ones in the toolshed. As they are used for the [assembly introduction in GTN](https://galaxyproject.github.io/training-material/topics/assembly/), currently only genouest and bipaa are listed as valid galaxy servers for this tutorial. It would be good to have at least one *big* instance listed I guess