### PR TITLE
added tools for RNA analysis found only in the RNA workbench

### DIFF
--- a/rnateam.yaml
+++ b/rnateam.yaml
@@ -76,7 +76,6 @@ tools:
     owner: rnateam
     tool_panel_section_label: RNA Analysis
 
-
   - name: cmcv
     owner: rnateam
     tool_panel_section_label: RNA Analysis
@@ -86,7 +85,9 @@ tools:
     tool_panel_section_label: RNA Analysis
 
   - name: dr_disco
-    owner:  erasmus-medical-center
+    owner: erasmus-medical-center
+    tool_panel_section_label: RNA Analysis
+
 
   - name: rnaz
     owner: rnateam


### PR DESCRIPTION
Added tools that are found on the Galaxy RNA workbench, but missing from rna.usegalaxy.eu:
- Dr. Disco
- CMCompare
- MEA
- RNAammer
