### PR TITLE
Clean up fastqc versions

### DIFF
--- a/tools_iuc.yaml.lock
+++ b/tools_iuc.yaml.lock
@@ -989,9 +989,7 @@ tools:
 - name: fastqc
   owner: devteam
   revisions:
-  - 3e1cdf5406db
   - 484e86282f4b
-  - c15237684a01
   - e28c965eeed4
   - 9da02be9c6cc
   tool_panel_section_label: FASTA/FASTQ manipulation


### PR DESCRIPTION
Remove outdated fastqc wrapper revisions with tool wrapper version 0.72.
Revision `9da02be9c6cc` represents the approved 0.72 version.