### PR TITLE
Update augustus_training

### DIFF
--- a/genome-annotation.yaml.lock
+++ b/genome-annotation.yaml.lock
@@ -26,6 +26,7 @@ tools:
   owner: bgruening
   revisions:
   - 86c89c3bd99d
+  - 1fbb1135da16
   tool_panel_section_label: Annotation
 - name: fasta_stats
   owner: simon-gladman


### PR DESCRIPTION
Ok, this one did not get auto updated as it's not owned by iuc.
For snap_training, the lock file was autoupdated, but the new version is not on usegalaxy.eu, is it normal?