### PR TITLE
Add tbvcfreport tool

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -1056,6 +1056,10 @@ tools:
     owner: iuc
     tool_panel_section_label: Annotation
 
+  - name: tbvcfreport
+    owner: iuc
+    tool_panel_section_label: Annotation
+
   - name: socru
     owner: iuc
     tool_panel_section_label: Annotation


### PR DESCRIPTION
Add the TB VCF Report tool, a tool for annotating VCF files of M. tuberculosis variants. This tool produces HTML output so needs to be whitelisted.