### PR TITLE
add snp_sites and snp_dists tools

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -2466,3 +2466,11 @@ tools:
   - name: moabs
     owner: iuc
     tool_panel_section_label: Epigenetics
+
+  - name: snp_sites
+    owner: iuc
+    tool_panel_section_label: Phylogenetics
+
+  - name: snp_dists
+    owner: iuc
+    tool_panel_section_label: Phylogenetics


### PR DESCRIPTION
* snp-sites works with multiple sequence alignments and can also extract a count of constant sites (see https://bitsandbugs.org/2019/11/06/two-easy-ways-to-run-iq-tree-with-the-correct-number-of-constant-sites/)
* snp-dists computes a SNP distance matrix from a multiple sequence alignment