### PR TITLE
Garnett, SCPred and CellTypeScan tools for HCA flavour

### DIFF
--- a/single-cell-ebi-gxa.yaml
+++ b/single-cell-ebi-gxa.yaml
@@ -219,6 +219,10 @@ tools:
   - name: monocle3_reducedim
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_monocle3_tools'
+    
+  - name: monocle3_topmarkers
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_monocle3_tools'
   
   - name: run_sccaf
     owner: ebi-gxa

--- a/single-cell-ebi-gxa.yaml
+++ b/single-cell-ebi-gxa.yaml
@@ -255,6 +255,10 @@ tools:
   - name: scmap_select_features
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scmap_tools'
+  
+  - name: scmap_get_std_output
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_scmap_tools'
     
   - name: ucsc_cell_browser
     owner: ebi-gxa
@@ -279,3 +283,79 @@ tools:
   - name: droplet_barcode_plot
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_utils_viz'
+    
+  - name: ct_build_cell_ontology_dict
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_label_analysis_tools'
+
+  - name: ct_combine_tool_outputs
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_label_analysis_tools'
+
+  - name: ct_get_consensus_outputs
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_label_analysis_tools'
+
+  - name: ct_get_empirical_dist
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_label_analysis_tools'
+
+  - name: ct_get_tool_perf_table
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_label_analysis_tools'
+
+  - name: ct_get_tool_pvals
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_label_analysis_tools'
+
+  - name: garnett_check_markers
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_garnett_tools'
+
+  - name: garnett_classify_cells
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_garnett_tools'
+
+  - name: garnett_get_feature_genes
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_garnett_tools'
+
+  - name: garnett_get_std_output
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_garnett_tools'
+
+  - name: garnett_train_classifier
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_garnett_tools'
+
+  - name: garnett_transform_markers
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_garnett_tools'
+
+  - name: update_marker_file
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_garnett_tools'
+
+  - name: scpred_eigen_decompose
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_scpred_tools'
+
+  - name: scpred_get_feature_space
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_scpred_tools'
+
+  - name: scpred_get_std_output
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_scpred_tools'
+
+  - name: scpred_predict_labels
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_scpred_tools'
+
+  - name: scpred_train_model
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_scpred_tools'
+
+  - name: scpred_traint_test_split
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_scpred_tools'


### PR DESCRIPTION
This PR adds Garnett, SCPred and CellTypeScan tools for the humancellatlas flavour. This should be merged after https://github.com/usegalaxy-eu/infrastructure-playbook/pull/177 is merged.