### PR TITLE
Add new legacy_tools.yaml

### DIFF
--- a/europe-custom.yaml
+++ b/europe-custom.yaml
@@ -1216,9 +1216,6 @@ tools:
   - name: tag_pileup_frequency
     owner: iuc
     tool_panel_section_label: 'SAM/BAM'
-  - name: sam_to_bam
-    owner: devteam
-    tool_panel_section_label: 'SAM/BAM'
   - name: pileup_interval
     owner: devteam
     tool_panel_section_label: 'SAM/BAM'
@@ -1271,9 +1268,6 @@ tools:
     owner: devteam
     tool_panel_section_label: 'SAM/BAM'
   - name: samtools_stats
-    owner: devteam
-    tool_panel_section_label: 'SAM/BAM'
-  - name: bam_to_sam
     owner: devteam
     tool_panel_section_label: 'SAM/BAM'
   - name: samtools_sort

--- a/europe-custom.yaml.lock
+++ b/europe-custom.yaml.lock
@@ -2104,11 +2104,6 @@ tools:
   - b7d7ae3963aa
   - fa82c3c9ced3
   tool_panel_section_label: SAM/BAM
-- name: sam_to_bam
-  owner: devteam
-  revisions:
-  - f7a0d41036c7
-  tool_panel_section_label: SAM/BAM
 - name: pileup_interval
   owner: devteam
   revisions:
@@ -2201,11 +2196,6 @@ tools:
   owner: devteam
   revisions:
   - 24c5d43cb545
-  tool_panel_section_label: SAM/BAM
-- name: bam_to_sam
-  owner: devteam
-  revisions:
-  - f57df915aa10
   tool_panel_section_label: SAM/BAM
 - name: samtools_sort
   owner: iuc

--- a/legacy_tools.yaml
+++ b/legacy_tools.yaml
@@ -1,0 +1,13 @@
+---
+install_repository_dependencies: true
+install_resolver_dependencies: true
+install_tool_dependencies: false
+
+tools:
+  - name: sam_to_bam
+    owner: devteam
+    tool_panel_section_label: 'SAM/BAM'
+  - name: bam_to_sam
+    owner: devteam
+    tool_panel_section_label: 'SAM/BAM'
+

--- a/legacy_tools.yaml.lock
+++ b/legacy_tools.yaml.lock
@@ -1,0 +1,21 @@
+install_repository_dependencies: true
+install_resolver_dependencies: true
+install_tool_dependencies: false
+tools:
+- name: sam_to_bam
+  owner: devteam
+  revisions:
+  - 30fdbaccb96b
+  - b77f7b516b17
+  - cf1ffd88f895
+  - f7a0d41036c7
+  tool_panel_section_label: SAM/BAM
+- name: bam_to_sam
+  owner: devteam
+  revisions:
+  - 88eedb4abea0
+  - dc20f447c0e2
+  - f57df915aa10
+  - f57df915aa10
+  tool_panel_section_label: SAM/BAM
+

--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -1759,9 +1759,6 @@ tools:
   - name: tag_pileup_frequency
     owner: iuc
     tool_panel_section_label: SAM/BAM
-  - name: sam_to_bam
-    owner: devteam
-    tool_panel_section_label: SAM/BAM
   - name: pileup_interval
     owner: devteam
     tool_panel_section_label: SAM/BAM
@@ -1832,10 +1829,6 @@ tools:
     tool_panel_section_label: SAM/BAM
 
   - name: samtools_stats
-    owner: devteam
-    tool_panel_section_label: SAM/BAM
-
-  - name: bam_to_sam
     owner: devteam
     tool_panel_section_label: SAM/BAM
 

--- a/tools_iuc.yaml.lock
+++ b/tools_iuc.yaml.lock
@@ -3210,14 +3210,6 @@ tools:
   - b7d7ae3963aa
   - fa82c3c9ced3
   tool_panel_section_label: SAM/BAM
-- name: sam_to_bam
-  owner: devteam
-  revisions:
-  - 30fdbaccb96b
-  - b77f7b516b17
-  - cf1ffd88f895
-  - f7a0d41036c7
-  tool_panel_section_label: SAM/BAM
 - name: pileup_interval
   owner: devteam
   revisions:
@@ -3357,13 +3349,6 @@ tools:
   - 793ad847121d
   - 8cfc17e27132
   - 95a7ddf617e7
-  tool_panel_section_label: SAM/BAM
-- name: bam_to_sam
-  owner: devteam
-  revisions:
-  - 88eedb4abea0
-  - dc20f447c0e2
-  - f57df915aa10
   tool_panel_section_label: SAM/BAM
 - name: samtools_depth
   owner: iuc


### PR DESCRIPTION
This is intended for outdated, hidden tools that should not receive automated updates anymore.

Migrates sam-to-bam and bam-to-sam as the first tools into the new file since these two are very old tools that can be replaced fully with samtools_view.

Hope this approach is correct?