### PR TITLE
Move old samtools sort iuc version to legacy_tools

### DIFF
--- a/europe-custom.yaml
+++ b/europe-custom.yaml
@@ -1270,9 +1270,6 @@ tools:
   - name: samtools_stats
     owner: devteam
     tool_panel_section_label: 'SAM/BAM'
-  - name: samtools_sort
-    owner: iuc
-    tool_panel_section_label: 'SAM/BAM'
   - name: sam_pileup
     owner: devteam
     tool_panel_section_label: 'SAM/BAM'

--- a/europe-custom.yaml.lock
+++ b/europe-custom.yaml.lock
@@ -2197,12 +2197,6 @@ tools:
   revisions:
   - 24c5d43cb545
   tool_panel_section_label: SAM/BAM
-- name: samtools_sort
-  owner: iuc
-  revisions:
-  - 38ea74bd4054
-  - 80fffde691eb
-  tool_panel_section_label: SAM/BAM
 - name: sam_pileup
   owner: devteam
   revisions:

--- a/legacy_tools.yaml
+++ b/legacy_tools.yaml
@@ -16,4 +16,7 @@ tools:
   - name: sam_bitwise_flag_filter
     owner: devteam
     tool_panel_section_label: 'SAM/BAM'
+  - name: samtools_sort
+    owner: iuc
+    tool_panel_section_label: SAM/BAM
 

--- a/legacy_tools.yaml.lock
+++ b/legacy_tools.yaml.lock
@@ -28,4 +28,10 @@ tools:
   revisions:
   - 0b2424a404d9
   tool_panel_section_label: SAM/BAM
+- name: samtools_sort
+  owner: iuc
+  revisions:
+  - 38ea74bd4054
+  - 80fffde691eb
+  tool_panel_section_label: SAM/BAM
 

--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -1836,10 +1836,6 @@ tools:
     owner: iuc
     tool_panel_section_label: SAM/BAM
 
-  - name: samtools_sort
-    owner: iuc
-    tool_panel_section_label: SAM/BAM
-
   - name: samtools_view
     owner: iuc
     tool_panel_section_label: SAM/BAM

--- a/tools_iuc.yaml.lock
+++ b/tools_iuc.yaml.lock
@@ -3359,12 +3359,6 @@ tools:
   revisions:
   - 44de678a44c4
   tool_panel_section_label: SAM/BAM
-- name: samtools_sort
-  owner: iuc
-  revisions:
-  - 38ea74bd4054
-  - 80fffde691eb
-  tool_panel_section_label: SAM/BAM
 - name: samtools_view
   owner: iuc
   revisions:


### PR DESCRIPTION
The latest version from tool_collections is owned by devteam and not touched here.