### PR TITLE
Move sklearn tools to ML section

### DIFF
--- a/ecology.yaml
+++ b/ecology.yaml
@@ -343,63 +343,63 @@ tools:
 
   - name: sklearn_svm_classifier
     owner: bgruening
-    tool_panel_section_label: 'Statistics'
+    tool_panel_section_label: 'Machine Learning'
 
   - name: sklearn_sample_generator
     owner: bgruening
-    tool_panel_section_label: 'Statistics'
+    tool_panel_section_label: 'Machine Learning'
 
   - name: sklearn_searchcv
     owner: bgruening
-    tool_panel_section_label: 'Statistics'
+    tool_panel_section_label: 'Machine Learning'
 
   - name: sklearn_build_pipeline
     owner: bgruening
-    tool_panel_section_label: 'Statistics'
+    tool_panel_section_label: 'Machine Learning'
 
   - name: sklearn_pairwise_metrics
     owner: bgruening
-    tool_panel_section_label: 'Statistics'
+    tool_panel_section_label: 'Machine Learning'
 
   - name: sklearn_nn_classifier
     owner: bgruening
-    tool_panel_section_label: 'Statistics'
+    tool_panel_section_label: 'Machine Learning'
 
   - name: sklearn_numeric_clustering
     owner: bgruening
-    tool_panel_section_label: 'Statistics'
+    tool_panel_section_label: 'Machine Learning'
 
   - name: sklearn_ensemble
     owner: bgruening
-    tool_panel_section_label: 'Statistics'
+    tool_panel_section_label: 'Machine Learning'
 
   - name: sklearn_feature_selection
     owner: bgruening
-    tool_panel_section_label: 'Statistics'
+    tool_panel_section_label: 'Machine Learning'
 
   - name: sklearn_data_preprocess
     owner: bgruening
-    tool_panel_section_label: 'Statistics'
+    tool_panel_section_label: 'Machine Learning'
 
   - name: sklearn_clf_metrics
     owner: bgruening
-    tool_panel_section_label: 'Statistics'
+    tool_panel_section_label: 'Machine Learning'
 
   - name: sklearn_regression_metrics
     owner: bgruening
-    tool_panel_section_label: 'Statistics'
+    tool_panel_section_label: 'Machine Learning'
 
   - name: sklearn_discriminant_classifier
     owner: bgruening
-    tool_panel_section_label: 'Statistics'
+    tool_panel_section_label: 'Machine Learning'
 
   - name: sklearn_generalized_linear
     owner: bgruening
-    tool_panel_section_label: 'Statistics'
+    tool_panel_section_label: 'Machine Learning'
 
   - name: sklearn_model_validation
     owner: bgruening
-    tool_panel_section_label: 'Statistics'
+    tool_panel_section_label: 'Machine Learning'
 
   - name: scipy_sparse
     owner: bgruening

--- a/ecology.yaml.lock
+++ b/ecology.yaml.lock
@@ -435,91 +435,91 @@ tools:
   revisions:
   - 1a9d5a8fff12
   - d2afc87db26b
-  tool_panel_section_label: Statistics
+  tool_panel_section_label: Machine Learning
 - name: sklearn_sample_generator
   owner: bgruening
   revisions:
   - 97b467e06354
   - b4ba9602a36e
-  tool_panel_section_label: Statistics
+  tool_panel_section_label: Machine Learning
 - name: sklearn_searchcv
   owner: bgruening
   revisions:
   - 1ae5dfd5ac17
   - 1c4a241bef5c
-  tool_panel_section_label: Statistics
+  tool_panel_section_label: Machine Learning
 - name: sklearn_build_pipeline
   owner: bgruening
   revisions:
   - 913ee94945f3
   - 97dce66fe158
-  tool_panel_section_label: Statistics
+  tool_panel_section_label: Machine Learning
 - name: sklearn_pairwise_metrics
   owner: bgruening
   revisions:
   - 7366e5108e9f
   - 86020dbc8ef7
-  tool_panel_section_label: Statistics
+  tool_panel_section_label: Machine Learning
 - name: sklearn_nn_classifier
   owner: bgruening
   revisions:
   - 39ae3c043096
   - e9ba818e7877
-  tool_panel_section_label: Statistics
+  tool_panel_section_label: Machine Learning
 - name: sklearn_numeric_clustering
   owner: bgruening
   revisions:
   - 1dd433d2c92c
   - abb5a3f256e3
-  tool_panel_section_label: Statistics
+  tool_panel_section_label: Machine Learning
 - name: sklearn_ensemble
   owner: bgruening
   revisions:
   - 3ab7af14f1b5
   - e94395c672bd
-  tool_panel_section_label: Statistics
+  tool_panel_section_label: Machine Learning
 - name: sklearn_feature_selection
   owner: bgruening
   revisions:
   - ae0fafb53c1d
   - ec25331946b8
-  tool_panel_section_label: Statistics
+  tool_panel_section_label: Machine Learning
 - name: sklearn_data_preprocess
   owner: bgruening
   revisions:
   - 826c3e68e7a9
   - 9e43ee712723
-  tool_panel_section_label: Statistics
+  tool_panel_section_label: Machine Learning
 - name: sklearn_clf_metrics
   owner: bgruening
   revisions:
   - 55703205546f
   - 9bf11bbeccc3
-  tool_panel_section_label: Statistics
+  tool_panel_section_label: Machine Learning
 - name: sklearn_regression_metrics
   owner: bgruening
   revisions:
   - 1e98dbb8d5bc
   - 40ee30b5e456
-  tool_panel_section_label: Statistics
+  tool_panel_section_label: Machine Learning
 - name: sklearn_discriminant_classifier
   owner: bgruening
   revisions:
   - 237ae72d58a3
   - 5552eda109bd
-  tool_panel_section_label: Statistics
+  tool_panel_section_label: Machine Learning
 - name: sklearn_generalized_linear
   owner: bgruening
   revisions:
   - 3e4a7684d402
   - b628de0d101f
-  tool_panel_section_label: Statistics
+  tool_panel_section_label: Machine Learning
 - name: sklearn_model_validation
   owner: bgruening
   revisions:
   - 0474777be433
   - cf9aa11b91c8
-  tool_panel_section_label: Statistics
+  tool_panel_section_label: Machine Learning
 - name: scipy_sparse
   owner: bgruening
   revisions:


### PR DESCRIPTION
Hopefully, https://github.com/usegalaxy-eu/infrastructure-playbook/pull/218 takes care of not losing the tools from the ecology subdomain.