### PR TITLE
Addition of CryptoGenotyper version 1.0+galaxy0 to Galaxy EU instance

### DIFF
--- a/nml.yaml
+++ b/nml.yaml
@@ -7,3 +7,6 @@ tools:
   - name: 'sistr_cmd'
     owner: 'nml'
     tool_panel_section_label: Annotation
+ - name: 'cryptogenotyper'
+   owner: 'nml'
+   tool_panel_section_label: Annotation


### PR DESCRIPTION
Thanks to help of @bgruening we are releasing an improved and more stable version of the `CryptoGenotyper` wrapper allowing to type `Cryptosporidium` species. We hope this tool will be more accessible to a wider audience and many thanks to all help we've got. 