### PR TITLE
Update SISTR on Galaxy-EU to v1.1.1

### DIFF
--- a/nml.yaml
+++ b/nml.yaml
@@ -7,3 +7,6 @@ tools:
   - name: 'sistr_cmd'
     owner: 'nml'
     tool_panel_section_label: Annotation
+ - name: 'cryptogenotyper'
+   owner: 'nml'
+   tool_panel_section_label: Annotation

--- a/nml.yaml.lock
+++ b/nml.yaml.lock
@@ -5,5 +5,6 @@ tools:
 - name: sistr_cmd
   owner: nml
   revisions:
+  - 17fcac7ddf54
   - 5c8ff92e38a9
   tool_panel_section_label: Annotation


### PR DESCRIPTION
Please update SISTR to the newest version 1.1.1 (current one is 1.0.2 on the server). Thank you for having our tool on your sever.