### PR TITLE
adding ectyper and mob_suite tools to the EU server

### DIFF
--- a/nml.yaml
+++ b/nml.yaml
@@ -10,3 +10,9 @@ tools:
   - name: 'cryptogenotyper'
     owner: 'nml'
     tool_panel_section_label: Annotation
+  - name: 'ectyper'
+    owner: 'nml'
+    tool_panel_section_label: Annotation
+  - name: 'mob_suite'
+    owner: 'nml'
+    tool_panel_section_label: Annotation

--- a/nml.yaml.lock
+++ b/nml.yaml.lock
@@ -13,3 +13,13 @@ tools:
   revisions:
   - d4a96287909e
   tool_panel_section_label: Annotation
+- name: ectyper
+  owner: nml
+  revisions:
+  - 08d801182fa1
+  tool_panel_section_label: Annotation
+- name: mob_suite
+  owner: nml
+  revisions:
+  - 822575bf359f
+  tool_panel_section_label: Annotation


### PR DESCRIPTION
This is a PR to add [ECTyper](https://github.com/phac-nml/ecoli_serotyping) and [MOB-Suite](https://github.com/phac-nml/mob-suite) tools that are useful for E.coli serotyping (similar to SISTR tool that is used for Salmonella serotyping) and plasmid reconstruction and typing. I think these two tools will be valuable addition to available set of tools especially in the context of public health and AMR. MOB-Suite is being successfully used by a large number of users and many like its simplicity and reporting format. Likewise we are publishing ECTyper manuscript in a couple of months and this tool availability will be very beneficial for end users (our galaxy server is unfortunately not public). Will be very grateful if these tools will be publicly available and will update badge signs on our repos (similar to CryptoGenotyper).