### PR TITLE
Included tool GECKO

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -127,6 +127,10 @@ tools:
   - name: chromeister
     owner: iuc
     tool_panel_section_label: Multiple Alignments
+    
+  - name: gecko
+    owner: iuc
+    tool_panel_section_label: Multiple Alignments
 
   - name: kc_align
     owner: iuc


### PR DESCRIPTION
This PR is to include the tool GECKO, which is already available in bioconda and tools-iuc. 
It has been included right below the CHROMEISTER tool, under category Multiple Alignments