### PR TITLE
remove gmx_npt and gmx_nvt

### DIFF
--- a/cheminformatics.yaml
+++ b/cheminformatics.yaml
@@ -129,10 +129,6 @@ tools:
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
   
-  - name: gmx_npt
-    owner: chemteam
-    tool_panel_section_label: ChemicalToolBox
-
   - name: md_converter
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox
@@ -152,10 +148,6 @@ tools:
   - name: gmx_md
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox 
-
-  - name: gmx_nvt
-    owner: chemteam
-    tool_panel_section_label: ChemicalToolBox
 
   - name: gmx_merge_topology_files
     owner: chemteam

--- a/cheminformatics.yaml.lock
+++ b/cheminformatics.yaml.lock
@@ -237,13 +237,6 @@ tools:
   revisions:
   - 30c673b5b061
   tool_panel_section_label: ChemicalToolBox
-- name: gmx_npt
-  owner: chemteam
-  revisions:
-  - 511b084adf53
-  - 5b01e6df25a0
-  - 93e39b0321c7
-  tool_panel_section_label: ChemicalToolBox
 - name: md_converter
   owner: chemteam
   revisions:
@@ -311,13 +304,6 @@ tools:
   - 2e28934c1d8c
   - 609d93596b61
   - d97433b7d482
-  tool_panel_section_label: ChemicalToolBox
-- name: gmx_nvt
-  owner: chemteam
-  revisions:
-  - 3a018cc1f690
-  - d861e980340f
-  - f425c1453662
   tool_panel_section_label: ChemicalToolBox
 - name: gmx_merge_topology_files
   owner: chemteam


### PR DESCRIPTION
remove gmx_npt and gmx_nvt as discussed with @simonbray 
These tools run using all cores available in the computing node, making it unusable.