### PR TITLE
add pe_histogram to tools_iuc

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -3323,3 +3323,7 @@ tools:
   - name: jvarkit_wgscoverageplotter
     owner: iuc
     tool_panel_section_label: Graph/Display Data
+
+  - name: pe_histogram
+    owner: iuc
+    tool_panel_section_label: Graph/Display Data


### PR DESCRIPTION
Hi,
Currently in usegalaxy.eu, there is a similar tool from the picard tool suite but it split the fr and rf which leads to a misleading plot. This raised a lot of questions during the GTN Smörgåsbord.
Thanks