### PR TITLE
Add dfornika's ivar_variants_to_vcf

### DIFF
--- a/diverse.yaml
+++ b/diverse.yaml
@@ -10,4 +10,5 @@ tools:
 
   - name:  ivar_variants_to_vcf
     owner: dfornika
+    toolshed: https://testtoolshed.g2.bx.psu.edu/
     tool_panel_section_label: Virology

--- a/diverse.yaml
+++ b/diverse.yaml
@@ -7,3 +7,7 @@ tools:
   - name: srnapipe
     owner: brasset_jensen
     tool_panel_section_label: RNA Analysis
+
+  - name:  ivar_variants_to_vcf
+    owner: dfornika
+    tool_panel_section_label: Virology

--- a/diverse.yaml
+++ b/diverse.yaml
@@ -10,5 +10,5 @@ tools:
 
   - name:  ivar_variants_to_vcf
     owner: dfornika
-    toolshed: https://testtoolshed.g2.bx.psu.edu/
+    tool_shed_url: https://testtoolshed.g2.bx.psu.edu/
     tool_panel_section_label: Virology


### PR DESCRIPTION
This is useful to feed output of ivar variants to SnpEff. The script is originally from the [viralrecon](https://github.com/nf-core/viralrecon) project.