### PR TITLE
update fastqc in the FASTQ Quality Control section'

### DIFF
--- a/europe-custom.yaml.lock
+++ b/europe-custom.yaml.lock
@@ -901,6 +901,7 @@ tools:
   owner: devteam
   revisions:
   - 484e86282f4b
+  - e7b2202befea
   tool_panel_section_label: FASTQ Quality Control
 - name: trimmomatic
   owner: pjbriggs


### PR DESCRIPTION
This PR will add the last fastqc version in the FASTQ Quality Control section but, I am puzzled by the fact we have this section with only one tool ,and it is completely different from others usegalaxy.* server.