### PR TITLE
Add proteomiqon_psmstatistics

### DIFF
--- a/tools_galaxyp.yaml
+++ b/tools_galaxyp.yaml
@@ -992,3 +992,7 @@ tools:
   - name: proteomiqon_peptidespectrummatching
     owner: galaxyp
     tool_panel_section_label: Proteomics
+
+  - name: proteomiqon_psmstatistics
+    owner: galaxyp
+    tool_panel_section_label: Proteomics


### PR DESCRIPTION
This PR adds the tool proteomiqon_psmstatistics.

If it's possible, we would appreciate if you could trigger a manual installation of this tool (and the next one).