### PR TITLE
Update MOB-Suite to version 3.0.3

### DIFF
--- a/nml.yaml.lock
+++ b/nml.yaml.lock
@@ -23,4 +23,5 @@ tools:
   owner: nml
   revisions:
   - 822575bf359f
+  - 93ba63eaf394
   tool_panel_section_label: Annotation


### PR DESCRIPTION
We had updated MOB-Suite to version 3.0.3 making it compatible with read-only file systems encountered in Galaxy Project servers and Singularity images. Thank you for making our tool available on the Galaxy EU platform. We see that many users use this tool to type and reconstruct plasmids from draft assemblies, so we hope users will enjoy this release.

PS: We are submitting our revisions on ECTyper manuscript by Aug 13th, so will be glad to write news announcement on ECTyper once we get publication accepted.

Have a nice weekend