### PR TITLE
Add loriket and spotyping

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -3637,3 +3637,11 @@ tools:
   
   - name: data_manager_metaphlan_database_downloader
     owner: iuc
+    
+  - name: lorikeet
+    owner: iuc
+    tool_panel_section_label: Annotation
+    
+  - name: spotyping
+    owner: iuc
+    tool_panel_section_label: Annotation


### PR DESCRIPTION
These are two tools for in-silico spoligotyping (spacer oligotyping) of M. tuberculosis data