### PR TITLE
Add lorikeet and spotyping

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -3637,3 +3637,12 @@ tools:
   
   - name: data_manager_metaphlan_database_downloader
     owner: iuc
+
+  - name: lorikeet_spoligotype
+    owner: iuc
+    tool_panel_section_label: Annotation
+    
+  - name: spotyping
+    owner: iuc
+    tool_panel_section_label: Annotation
+    


### PR DESCRIPTION
These are tools for in-silico spoligotyping (space oligotyping) of M. tuberculosis data