### PR TITLE
adding maaslin2 tool to tools iuc yml file

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -6,7 +6,7 @@ install_tool_dependencies: false
 tools:
   - name: maaslin2
     owner: iuc
-    tool_panel_section_label: Microbiom R Analysis
+    tool_panel_section_label: Metagenomic Analysis
     
   - name: instrain_profile
     owner: iuc

--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -4,6 +4,10 @@ install_resolver_dependencies: true
 install_tool_dependencies: false
 
 tools:
+  - name: maaslin2
+    owner: iuc
+    tool_panel_section_label: Microbiom R Analysis
+    
   - name: instrain_profile
     owner: iuc
     tool_panel_section_label: Metagenomic Analysis


### PR DESCRIPTION
Step 3 - request for installation :))

Adding [**MaAsLin2**](http://huttenhower.sph.harvard.edu/maaslin) tool: which is comprehensive R package for efficiently determining multivariable association between phenotypes, environments, exposures, covariates and microbial meta’omic features. MaAsLin2 relies on general linear models to accommodate most modern epidemiological study designs, including cross-sectional and longitudinal, and offers a variety of data exploration, normalization, and transformation methods.

MaAsLin2 [PR](https://github.com/galaxyproject/tools-iuc/pull/4128)