### PR TITLE
Add GECCO to `europe-custom.yaml`

### DIFF
--- a/europe-custom.yaml
+++ b/europe-custom.yaml
@@ -1390,3 +1390,7 @@ tools:
   - name: stacks_populations
     owner: iuc
     tool_panel_section_label: RAD-seq
+
+  - name: gecco
+    owner: althonos
+    tool_panel_section_label: Annotation

--- a/europe-custom.yaml.lock
+++ b/europe-custom.yaml.lock
@@ -2560,3 +2560,8 @@ tools:
   - 47e83073b7a1
   - d504d945a655
   tool_panel_section_label: RAD-seq
+- name: gecco
+  owner: althonos
+  revisions:
+  - 359232b58f6a
+  tool_panel_section_label: Annotation


### PR DESCRIPTION
Hi! This is my first time writing a Galaxy tool wrapper so I hope I did everything properly.

This PR adds the wrapper for [GECCO](https://gecco.embl.de), a new method developed by the [Zeller lab](https://github/zellerlab) at EMBL. I added it to `europe-custom.yaml` since that's where the `antiSMASH` repository is located, and conceptually GECCO has the same purpose.