### PR TITLE
Add read_it_and_keep - for decontaminating viral FASTQ reads

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -1371,6 +1371,10 @@ tools:
     owner: devteam
     tool_panel_section_label: FASTA/FASTQ
 
+  - name: read_it_and_keep
+    owner: iuc
+    tool_panel_section_label: FASTA/FASTQ
+
   - name: mitobim
     owner: iuc
     tool_panel_section_label: Assembly


### PR DESCRIPTION
This is a new tool for decontaminating (i.e. host removal etc) viral FASTQ reads.

I was not sure which section to put it in so I put it in the same section as FastqQC etc.