### PR TITLE
add mcl tool

### DIFF
--- a/brinkmanlab.yaml
+++ b/brinkmanlab.yaml
@@ -1,0 +1,9 @@
+---
+install_repository_dependencies: true
+install_resolver_dependencies: true
+install_tool_dependencies: false
+
+tools:
+  - name: 'mcl'
+    owner: 'brinkmanlab'
+    tool_panel_section_label: Machine Learning

--- a/brinkmanlab.yaml
+++ b/brinkmanlab.yaml
@@ -1,9 +1,0 @@
----
-install_repository_dependencies: true
-install_resolver_dependencies: true
-install_tool_dependencies: false
-
-tools:
-  - name: 'mcl'
-    owner: 'brinkmanlab'
-    tool_panel_section_label: Machine Learning

--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -3990,3 +3990,7 @@ tools:
   - name: hypo
     owner: iuc
     tool_panel_section_label: Assembly
+
+  - name: mcl
+    owner: iuc
+    tool_panel_section_label: Machine Learning


### PR DESCRIPTION
## Add mcl markov clustering tool

Request to add [mcl](https://micans.org/mcl/) - [galaxy-wrapper](https://toolshed.g2.bx.psu.edu/repository?repository_id=d55826498c75f75f&changeset_revision=60609b076830) as a tool. It is maintained by "brinkmanlab" here: https://github.com/brinkmanlab/galaxy-tools/tree/master/mcl.

Since no other tool from this maintainer is available i created a new yaml file. Feel free to change that if there is a more appropriate place for it.