### PR TITLE
Add clair3

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -497,6 +497,10 @@ tools:
     owner: iuc
     tool_panel_section_label: Nanopore
 
+  - name: clair3
+    owner: iuc
+    tool_panel_section_label: Nanopore
+
   - name: artic_guppyplex
     owner: iuc
     tool_panel_section_label: Variant Calling


### PR DESCRIPTION
Add [clair3](https://github.com/galaxyproject/tools-iuc/tree/master/tools/clair3), a variant caller for Nanopore data.