### PR TITLE
Remove duplicate freyja tools from yaml and lock files

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -3632,22 +3632,6 @@ tools:
     owner: iuc
     tool_panel_section_label: Convert Formats
 
-  - name: freyja_variants
-    owner: iuc
-    tool_panel_section_label: Phylogenetics
-
-  - name: freyja_demix
-    owner: iuc
-    tool_panel_section_label: Phylogenetics
-
-  - name: freyja_boot
-    owner: iuc
-    tool_panel_section_label: Phylogenetics
-
-  - name: freyja_aggregate_plot
-    owner: iuc
-    tool_panel_section_label: Phylogenetics
-
   - name: nextclade
     owner: iuc
     tool_panel_section_label: Phylogenetics

--- a/tools_iuc.yaml.lock
+++ b/tools_iuc.yaml.lock
@@ -7745,26 +7745,6 @@ tools:
   - 75a14cc16d4d
   - b026dae67fba
   tool_panel_section_label: Convert Formats
-- name: freyja_variants
-  owner: iuc
-  revisions:
-  - 08c2d81e7942
-  tool_panel_section_label: Phylogenetics
-- name: freyja_demix
-  owner: iuc
-  revisions:
-  - fc6252e78d5b
-  tool_panel_section_label: Phylogenetics
-- name: freyja_boot
-  owner: iuc
-  revisions:
-  - dda5772507b2
-  tool_panel_section_label: Phylogenetics
-- name: freyja_aggregate_plot
-  owner: iuc
-  revisions:
-  - 0ceb9fb0f4ce
-  tool_panel_section_label: Phylogenetics
 - name: nextclade
   owner: iuc
   revisions:


### PR DESCRIPTION
New attempt, this time removing freyja duplicates also from the .lock file to which it's been added overnight.