### PR TITLE
Adding srst2

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -4,6 +4,10 @@ install_resolver_dependencies: true
 install_tool_dependencies: false
 
 tools:
+  - name: srst2
+    owner: iuc
+    tool_panel_section_label: Metagenomic Analysis
+    
   - name: maaslin2
     owner: iuc
     tool_panel_section_label: Microbiom R Analysis

--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -4,6 +4,10 @@ install_resolver_dependencies: true
 install_tool_dependencies: false
 
 tools:
+  - name: maaslin2
+    owner: iuc
+    tool_panel_section_label: Microbiom R Analysis
+    
   - name: instrain_profile
     owner: iuc
     tool_panel_section_label: Metagenomic Analysis


### PR DESCRIPTION
Adding [SRST2](https://github.com/katholt/srst2) (Short Read Sequence Typing for Bacterial Pathogens) tool to usegalaxy.eu: 

This tool is designed to take Illumina sequence data, a MLST database and/or a database of gene sequences (e.g. resistance genes, virulence genes, etc) and report the presence of STs and/or reference genes.

Thanks a lot,
Engy