### PR TITLE
adding SRST2 tool for Short Read Sequence Typing for Bacterial Pathogens

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -5,6 +5,10 @@ install_tool_dependencies: false
 
 tools:
 
+  - name: srst2
+    owner: iuc
+    tool_panel_section_label: Metagenomic Analysis
+
   - name: adapter_removal
     owner: iuc
     tool_panel_section_label: FASTA/FASTQ


### PR DESCRIPTION
I forgot to change in my fork and added the tool directly, is that ok ? 

Adding [SRST2](https://github.com/katholt/srst2) (Short Read Sequence Typing for Bacterial Pathogens) tool to usegalaxy.eu:

This tool is designed to take Illumina sequence data, a MLST database and/or a database of gene sequences (e.g. resistance genes, virulence genes, etc) and report the presence of STs and/or reference genes.

Thanks a lot,
Engy