### PR TITLE
Add te_finder to usegalaxy.eu

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -4215,3 +4215,6 @@ tools:
   - name: cooc_tabmut
     owner: iuc
     tool_panel_section_label: Virology
+
+  - name: te_finder
+    owner: iuc


### PR DESCRIPTION
Want to add wrapper for TEfinder #4700 from https://github.com/galaxyproject/tools-iuc

Please advice what checks are required to push this wrapper to the public usegalaxy.eu server