### PR TITLE
Add first batch of CPT phage annotation tools

### DIFF
--- a/tools_galaxyp.yaml
+++ b/tools_galaxyp.yaml
@@ -1036,3 +1036,47 @@ tools:
   - name: metanovo
     owner: galaxyp
     tool_panel_section_label: Proteomics
+    
+  - name: cpt_fasta_remove_id
+    owner: cpt
+    tool_panel_section_label: FASTA/FASTQ
+    
+  - name: cpt_get_orfs
+    owner: cpt
+    tool_panel_section_label: Annotation
+    
+  - name: cpt_convert_mga
+    owner: cpt
+    tool_panel_section_label: Convert Formats
+    
+  - name: cpt_gff_add_parent
+    owner: cpt
+    tool_panel_section_label: Annotation
+    
+  - name: cpt_fix_aragorn
+    owner: cpt
+    tool_panel_section_label: Convert Formats
+    
+  - name: cpt_fix_sixpack
+    owner: cpt
+    tool_panel_section_label: Annotation
+    
+  - name: cpt_shinefind
+    owner: cpt
+    tool_panel_section_label: Annotation
+    
+  - name: cpt_type_filter
+    owner: cpt
+    tool_panel_section_label: Annotation
+    
+  - name: cpt_req_phage_start
+    owner: cpt
+    tool_panel_section_label: Annotation
+    
+  - name: cpt_rem_annotes
+    owner: cpt
+    tool_panel_section_label: Annotation
+    
+  - name: cpt_gff_apollo_prep
+    owner: cpt
+    tool_panel_section_label: Annotation


### PR DESCRIPTION
Requested 11 tools needed for the structural annotation workflow, tools are all in the CPT-ToolshedSource repo. If tools can go into IUC that may be easier?