### PR TITLE
Add revertr2orientationinbam

### DIFF
--- a/rnateam.yaml
+++ b/rnateam.yaml
@@ -119,3 +119,8 @@ tools:
   - name: cofold
     owner: rnateam
     tool_panel_section_label: RNA Analysis
+
+
+  - name: revertr2orientationinbam
+    owner: lldelisle
+    tool_panel_section_label: SAM/BAM


### PR DESCRIPTION
Dear Usegalaxy.eu team,
I would like to have my tool revertr2orientationinbam installed as it is used by the iwc workflow RNAseq-PE (https://github.com/galaxyproject/iwc/blob/49cd92c5746c2c6977f60bc4e9dea3f05bffd6c2/workflows/transcriptomics/rnaseq-pe/rnaseq-pe.ga).
Indeed this is used to get strand specific coverage from paired-end data.
BAM -> revertr2orientationinbam -> bedtools genomecov
This solution is much quicker than using deeptools bamCoverage as bedtools is written in C.