### PR TITLE
add dewseq + htseq-clip to galaxy

### DIFF
--- a/bgruening.yaml
+++ b/bgruening.yaml
@@ -298,8 +298,8 @@ tools:
 
   - name: dewseq
     owner: rnateam
-    tool_panel_section_label: CLIP-seq
+    tool_panel_section_label: Peak Calling
 
   - name: htseq_clip
     owner: rnateam
-    tool_panel_section_label: CLIP-seq
+    tool_panel_section_label: Peak Calling

--- a/bgruening.yaml
+++ b/bgruening.yaml
@@ -295,3 +295,11 @@ tools:
   - name: minipolish
     owner: bgruening
     tool_panel_section_label: Assembly
+
+  - name: dewseq
+    owner: rnateam
+    tool_panel_section_label: CLIP-seq
+
+  - name: htseq_clip
+    owner: rnateam
+    tool_panel_section_label: CLIP-seq

--- a/rnateam.yaml
+++ b/rnateam.yaml
@@ -119,3 +119,11 @@ tools:
   - name: cofold
     owner: rnateam
     tool_panel_section_label: RNA Analysis
+
+  - name: dewseq
+    owner: rnateam
+    tool_panel_section_label: Peak Calling
+
+  - name: htseq_clip
+    owner: rnateam
+    tool_panel_section_label: Peak Calling


### PR DESCRIPTION
Add DEWSeq + htseq-clip to usegalaxy.eu. It would be great to have a new tool_panel_section_label "CLIP-seq" here, just like there is already one for "ChIP-seq" tools on usegalaxy.eu.