### PR TITLE
Update GECCO to `v0.9.6`

### DIFF
--- a/europe-custom.yaml.lock
+++ b/europe-custom.yaml.lock
@@ -2632,6 +2632,7 @@ tools:
 - name: gecco
   owner: althonos
   revisions:
+  - cc91d730cc4f
   - 359232b58f6a
   tool_panel_section_label: Annotation
 - name: velvet


### PR DESCRIPTION
As mentioned in #440, GECCO does not receive automatic updates. This PR bumps it to `v0.9.6`, the latest version.