### PR TITLE
add filter_tabular 3.3.0; preserve filter_tabular 2.0.0

### DIFF
--- a/tools_galaxyp.yaml.lock
+++ b/tools_galaxyp.yaml.lock
@@ -229,6 +229,7 @@ tools:
   - 666f3453a99d
   - 74f5d355d156
   - 7f432d87c82c
+  - 837224ad1694
   - 8bac3cc5c5de
   - 97a7f34fcb6a
   - d72c96ad9a16
@@ -2270,10 +2271,12 @@ tools:
 - name: mqppep_preproc
   owner: galaxyp
   revisions:
+  - 5c2beb4eb41c
   - bae3a23461c9
   tool_panel_section_label: Proteomics
 - name: mqppep_anova
   owner: galaxyp
   revisions:
+  - 2d9f216c1048
   - dda27b9273a8
   tool_panel_section_label: Proteomics

--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -3895,6 +3895,10 @@ tools:
     owner: devteam
     tool_panel_section_label: Text Manipulation
 
+  - name: filter_tabular
+    owner: iuc
+    tool_panel_section_label: Text Manipulation
+
   - name: flanking_features
     owner: devteam
     tool_panel_section_label: Text Manipulation

--- a/tools_iuc.yaml.lock
+++ b/tools_iuc.yaml.lock
@@ -8366,7 +8366,6 @@ tools:
   owner: iuc
   revisions:
   - 4d5aae46f850
-  - 34d29339abab
   tool_panel_section_label: Text Manipulation
 - name: flanking_features
   owner: devteam

--- a/tools_iuc.yaml.lock
+++ b/tools_iuc.yaml.lock
@@ -8362,6 +8362,12 @@ tools:
   revisions:
   - 549d2cb4c6f2
   tool_panel_section_label: Text Manipulation
+- name: filter_tabular
+  owner: iuc
+  revisions:
+  - 4d5aae46f850
+  - 34d29339abab
+  tool_panel_section_label: Text Manipulation
 - name: flanking_features
   owner: devteam
   revisions:


### PR DESCRIPTION
@bgruening @hexylena 

This PR is to add `filter_tabular` to `tools_iuc.yaml`

Regarding the additions to `tools_iuc.yaml.lock`
`filter_tabular` 2.0.0 (revision 34d29339abab) is presently installed on UseGalaxy.eu
`filter_tabular` 3.3.0 (revision 4d5aae46f850) is to be installed onto UseGalaxy.eu

Thank you.

P.S. When I ran
```make fix```
it identified a number of issues that I did not include in this PR because it did not concern this tool. 