### PR TITLE
Prevent installation of slow 1.3.2 version of ivar trim

### DIFF
--- a/tools_iuc.yaml.lock
+++ b/tools_iuc.yaml.lock
@@ -9762,7 +9762,6 @@ tools:
   - 8858fa037a15
   - 9f978da6528a
   - a2b94388d00d
-  - bcaa0d571ce2
   - c092052ed673
   - cb903c9dc33d
   - cf65217ad61c


### PR DESCRIPTION
redoing [4295a3d], after which the version probably got rediscovered as latest.
Now that we have 1.4.0 installed, this shouldn't happen again (I hope).