### PR TITLE
Add PepQuery2 tools

### DIFF
--- a/tools_galaxyp.yaml
+++ b/tools_galaxyp.yaml
@@ -1052,3 +1052,15 @@ tools:
   - name: mqppep_anova
     owner: galaxyp
     tool_panel_section_label: Proteomics
+
+  - name: pepquery2
+    owner: galaxyp
+    tool_panel_section_label: Proteomics
+
+  - name: pepquery2_show_sets
+    owner: galaxyp
+    tool_panel_section_label: Proteomics
+
+  - name: pepquery2_index
+    owner: galaxyp
+    tool_panel_section_label: Proteomics


### PR DESCRIPTION
Adds `pepquery2`, `pepquery2_index`, and `pepquery2_show_sets` under the Proteomics label.

I gleaned that adding a separate entry for each tool was preferred to an entry for the `suite_pepquery2` suite, but please let me know if that's not correct.