### PR TITLE
Add RECETOX tools

### DIFF
--- a/eirene.yaml
+++ b/eirene.yaml
@@ -1,0 +1,52 @@
+---
+install_repository_dependencies: true
+install_resolver_dependencies: true
+install_tool_dependencies: false
+tools:
+  - name: recetox_aplcms_generate_feature_table
+    owner: recetox
+    tool_panel_section_label: Metabolomics
+
+  - name: recetox_aplcms_recover_weaker_signals
+    owner: recetox
+    tool_panel_section_label: Metabolomics
+
+  - name: recetox_aplcms_correct_time
+    owner: recetox
+    tool_panel_section_label: Metabolomics
+
+  - name: recetox_aplcms_compute_clusters
+    owner: recetox
+    tool_panel_section_label: Metabolomics
+
+  - name: recetox_aplcms_remove_noise
+    owner: recetox
+    tool_panel_section_label: Metabolomics
+
+  - name: recetox_aplcms_merge_known_table
+    owner: recetox
+    tool_panel_section_label: Metabolomics
+
+  - name: recetox_aplcms_compute_template
+    owner: recetox
+    tool_panel_section_label: Metabolomics
+
+  - name: recetox_aplcms_align_features
+    owner: recetox
+    tool_panel_section_label: Metabolomics
+
+  - name: rmassbank
+    owner: recetox
+    tool_panel_section_label: Metabolomics
+
+  - name: biotransformer
+    owner: recetox
+    tool_panel_section_label: Metabolomics
+
+  - name: msmetaenhancer
+    owner: recetox
+    tool_panel_section_label: Metabolomics
+
+  - name: riassigner
+    owner: recetox
+    tool_panel_section_label: Metabolomics


### PR DESCRIPTION
First wave of adding RECETOX tools to usegalaxy.eu.
This PR brings tools `recetox-aplcms`, `MSMetaEnhancer`, `RIAssginer`, `RAMClustR`, `Biotransformer`, and `RMassBank` to Metabolimics section.