### PR TITLE
Add mosdepth tool

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -3726,6 +3726,9 @@ tools:
     owner: iuc
     tool_panel_section_label: SAM/BAM
 
+  - name: mosdepth
+    owner: iuc
+    tool_panel_section_label: SAM/BAM
 
 # SANGER SEQUENCING
 


### PR DESCRIPTION
This adds mosdepth, a small but useful tool for SAM/BAM depth reporting (which I plan to use to built better reporting for amplicon depth)