### PR TITLE
Update materials tools for MSS 2.2.1 and PMS 0.3.0

### DIFF
--- a/materials.yaml
+++ b/materials.yaml
@@ -16,6 +16,10 @@ tools:
     owner: muon-spectroscopy-computational-project
     tool_panel_section_label: Muon Spectroscopy
 
+  - name: muspinsim_combine
+    owner: muon-spectroscopy-computational-project
+    tool_panel_section_label: Muon Spectroscopy
+
   - name: muspinsim_plot
     owner: muon-spectroscopy-computational-project
     tool_panel_section_label: Muon Spectroscopy

--- a/materials.yaml.lock
+++ b/materials.yaml.lock
@@ -5,36 +5,47 @@ tools:
 - name: cif2cell
   owner: muon-spectroscopy-computational-project
   revisions:
+  - e5f1ac42b063
   - 60ad7a4f1faf
   - a2583fac03ab
   tool_panel_section_label: Muon Spectroscopy
 - name: muspinsim_config
   owner: muon-spectroscopy-computational-project
   revisions:
+  - e1e338f56656
   - 331d0776abb4
   - 52d3a28902e8
   tool_panel_section_label: Muon Spectroscopy
 - name: muspinsim
   owner: muon-spectroscopy-computational-project
   revisions:
+  - e002cee8f707
   - 136ed45d1ea9
   - b30217097125
+  tool_panel_section_label: Muon Spectroscopy
+- name: muspinsim_combine
+  owner: muon-spectroscopy-computational-project
+  revisions:
+  - 06aabd70b869
   tool_panel_section_label: Muon Spectroscopy
 - name: muspinsim_plot
   owner: muon-spectroscopy-computational-project
   revisions:
+  - e15e8800c39e
   - b53cbb8ad124
   - d7a0a31760b1
   tool_panel_section_label: Muon Spectroscopy
 - name: pm_asephonons
   owner: muon-spectroscopy-computational-project
   revisions:
+  - fd28cbdb134e
   - 641fda3dfb62
   - dd3ca8457fcd
   tool_panel_section_label: Muon Spectroscopy
 - name: pm_symmetry
   owner: muon-spectroscopy-computational-project
   revisions:
+  - c062cefbb20f
   - 620ab6826b9b
   - d8146a73b011
   tool_panel_section_label: Muon Spectroscopy
@@ -53,6 +64,7 @@ tools:
 - name: pm_uep_opt
   owner: muon-spectroscopy-computational-project
   revisions:
+  - ec5f6b22417c
   - 523d44fcd03f
   - 8f41a71fc710
   tool_panel_section_label: Muon Spectroscopy
@@ -65,6 +77,7 @@ tools:
 - name: pm_muairss_read
   owner: muon-spectroscopy-computational-project
   revisions:
+  - 40071ff77285
   - 276a25ab05f2
   - eb6382889b92
   tool_panel_section_label: Muon Spectroscopy

--- a/materials.yaml.lock
+++ b/materials.yaml.lock
@@ -64,7 +64,7 @@ tools:
 - name: pm_uep_opt
   owner: muon-spectroscopy-computational-project
   revisions:
-  - ec5f6b22417c
+  - eea73e1f65cb
   - 523d44fcd03f
   - 8f41a71fc710
   tool_panel_section_label: Muon Spectroscopy


### PR DESCRIPTION
Adds utility tool for MuSpinSim, and version updates for most `muon-spectroscopy-computational-project` tools.