### PR TITLE
Fix GCMS training tool availability

### DIFF
--- a/eirene.yaml.lock
+++ b/eirene.yaml.lock
@@ -84,6 +84,7 @@ tools:
 - name: ramclustr
   owner: recetox
   revisions:
+  - 050cfef6ba65
   - 9b716db0a786
   tool_panel_section_label: Metabolomics
 - name: ramclustr_define_experiment

--- a/metabolomics.yaml.lock
+++ b/metabolomics.yaml.lock
@@ -6,6 +6,7 @@ tools:
   owner: lecorguille
   revisions:
   - 86a20118e743
+  - 11ab2081bd4a
   tool_panel_section_label: Metabolomics
 - name: genform
   owner: workflow4metabolomics
@@ -17,23 +18,27 @@ tools:
   revisions:
   - 15646e937936
   - 3bd53dcfa438
+  - b02d1992a43a
   tool_panel_section_label: Metabolomics
 - name: xcms_plot_chromatogram
   owner: lecorguille
   revisions:
   - 271c9d5f0d10
+  - 024974037c4e
   tool_panel_section_label: Metabolomics
 - name: xcms_merge
   owner: lecorguille
   revisions:
   - 47f9b1fd5ce6
   - a301f001835c
+  - 5bd125a3f3b0
   tool_panel_section_label: Metabolomics
 - name: xcms_group
   owner: lecorguille
   revisions:
   - 9e45e1c404a4
   - fe4002ac5193
+  - d45a786cbc40
   tool_panel_section_label: Metabolomics
 - name: xcms_refine
   owner: workflow4metabolomics
@@ -45,12 +50,14 @@ tools:
   revisions:
   - 4bfef820569b
   - 7faadba7c625
+  - aa252eec9229
   tool_panel_section_label: Metabolomics
 - name: xcms_fillpeaks
   owner: lecorguille
   revisions:
   - 3bc94c3abb28
   - de0d85537ee3
+  - 26d77e9ceb49
   tool_panel_section_label: Metabolomics
 - name: camera_annotate
   owner: lecorguille
@@ -63,6 +70,7 @@ tools:
   revisions:
   - 27e7da5f6848
   - acc0a4a366c1
+  - 018a9771de28
   tool_panel_section_label: Metabolomics
 - name: camera_combinexsannos
   owner: mmonsoor
@@ -389,6 +397,7 @@ tools:
   owner: galaxyp
   revisions:
   - 9ec469ff191a
+  - 6153e8ada1ee
   tool_panel_section_label: Metabolomics
 - name: thermo_raw_file_converter
   owner: galaxyp


### PR DESCRIPTION
This RAMClustR version is the one currently required by the GC-MS Galaxy training and would be great if it was available on usegalaxy.eu.