### PR TITLE
Remove Trinity 2.15.1+galaxy0

### DIFF
--- a/europe-custom.yaml.lock
+++ b/europe-custom.yaml.lock
@@ -1262,7 +1262,6 @@ tools:
   - 5b60313a6ce7
   - 606b7748965d
   - 77cf519a812e
-  - 9fa24d5aac68
   - c9cfec002f71
   - d2bc35f3d1c5
   - d5e8807a407d

--- a/tools_iuc.yaml.lock
+++ b/tools_iuc.yaml.lock
@@ -7858,7 +7858,6 @@ tools:
   - 5b60313a6ce7
   - 606b7748965d
   - 77cf519a812e
-  - 9fa24d5aac68
   - c9cfec002f71
   - ca0588b09438
   - d2bc35f3d1c5


### PR DESCRIPTION
This version of Trinity is broken, see galaxyproject/usegalaxy-tools#630.