### PR TITLE
Update eirene.yaml.lock file with versions required for GCMS training

### DIFF
--- a/eirene.yaml
+++ b/eirene.yaml
@@ -102,3 +102,7 @@ tools:
   - name: matchms_split
     owner: recetox
     tool_panel_section_label: Metabolomics
+
+  - name: waveica
+    owner: recetox
+    tool_panel_section_label: Metabolomics

--- a/eirene.yaml.lock
+++ b/eirene.yaml.lock
@@ -86,11 +86,13 @@ tools:
   revisions:
   - 050cfef6ba65
   - 9b716db0a786
+  - 2ec9253a647e
   tool_panel_section_label: Metabolomics
 - name: ramclustr_define_experiment
   owner: recetox
   revisions:
   - 5f2b58dadb39
+  - 25625114618e
   tool_panel_section_label: Metabolomics
 - name: recetox_xmsannotator_advanced
   owner: recetox
@@ -107,6 +109,7 @@ tools:
   owner: recetox
   revisions:
   - a177ac3c752c
+  - 357df6c47d92
   tool_panel_section_label: Metabolomics
 - name: matchms_fingerprint_similarity
   owner: recetox

--- a/eirene.yaml.lock
+++ b/eirene.yaml.lock
@@ -151,3 +151,8 @@ tools:
   revisions:
   - 0cf68b536cd1
   tool_panel_section_label: Metabolomics
+- name: waveica
+  owner: recetox
+  revisions:
+  - b77023c41c76
+  tool_panel_section_label: Metabolomics


### PR DESCRIPTION
@bgruening should these not somehow be automatically updated? For some reason, the training apparently contains versions which are not on EU, eventhough we didn't update the training since we brought all the tools to EU if I am not mistaken.