### PR TITLE
removes old version of tool with wrong id

### DIFF
--- a/imaging.yaml.lock
+++ b/imaging.yaml.lock
@@ -10,6 +10,7 @@ tools:
   owner: imgteam
   revisions:
   - 589af0005df5
+  - b74693340624
   - bf590a9733ed
   tool_panel_section_label: Imaging
 - name: color_deconvolution

--- a/imaging.yaml.lock
+++ b/imaging.yaml.lock
@@ -285,6 +285,7 @@ tools:
 - name: bfconvert
   owner: imgteam
   revisions:
+  - 10eed33aa9b2
   - b07f4839ca77
   - f3360fbeda64
   tool_panel_section_label: Imaging

--- a/imaging.yaml.lock
+++ b/imaging.yaml.lock
@@ -197,7 +197,6 @@ tools:
   owner: imgteam
   revisions:
   - 9bd039f46843
-  - dcc8c1d6af48
   tool_panel_section_label: Imaging
 - name: labelimage2points
   owner: imgteam


### PR DESCRIPTION
Currently the tool "Points to Label" exists twice:
<img width="276" alt="Bildschirmfoto 2023-11-02 um 16 31 37" src="https://github.com/usegalaxy-eu/usegalaxy-eu-tools/assets/6557139/17b0eb76-3b38-4978-94b4-3a9196f32746">

These are two versions of the same tool, where one version had a misspelled ID:
- `ip_points_to_label`: https://github.com/BMCV/galaxy-image-analysis/blob/b2acc1845a25828181597fe5b6982fe116a7796d/tools/points2labelimage/points2label.xml
- `ip_points_to_labe`: https://github.com/BMCV/galaxy-image-analysis/blob/e7861412960f2c73e88d03279ab14a8b824cf11c/tools/points2labelimage/points2label.xml

This PR removes the version with the misspelled ID, so the tool doesn't appear twice.

---

PS. I have no clue why the commits 67e421e, e55ce05, abc1cbf are listed below, they were already merged with a previous PR of mine.