### PR TITLE
updates imaging tools to latest revisions

### DIFF
--- a/imaging.yaml
+++ b/imaging.yaml
@@ -84,10 +84,6 @@ tools:
     owner: imgteam
     tool_panel_section_label: "Imaging"
 
-  - name: 2d_split_binaryimage_by_watershed
-    owner: imgteam
-    tool_panel_section_label: "Imaging"
-    
   - name: 2d_filter_segmentation_by_features
     owner: imgteam
     tool_panel_section_label: "Imaging"

--- a/imaging.yaml
+++ b/imaging.yaml
@@ -84,6 +84,10 @@ tools:
     owner: imgteam
     tool_panel_section_label: "Imaging"
 
+  - name: 2d_split_binaryimage_by_watershed
+    owner: imgteam
+    tool_panel_section_label: "Imaging"
+    
   - name: 2d_filter_segmentation_by_features
     owner: imgteam
     tool_panel_section_label: "Imaging"

--- a/imaging.yaml.lock
+++ b/imaging.yaml.lock
@@ -10,6 +10,7 @@ tools:
   owner: imgteam
   revisions:
   - 589af0005df5
+  - b74693340624
   - bf590a9733ed
   tool_panel_section_label: Imaging
 - name: color_deconvolution

--- a/imaging.yaml.lock
+++ b/imaging.yaml.lock
@@ -77,6 +77,7 @@ tools:
 - name: rfove
   owner: imgteam
   revisions:
+  - d10a46ef77d3
   - ddff439fac16
   tool_panel_section_label: Imaging
 - name: landmark_registration
@@ -158,12 +159,6 @@ tools:
   - d0960e1b25a8
   - f8f1100d0701
   tool_panel_section_label: Imaging
-- name: 2d_split_binaryimage_by_watershed
-  owner: imgteam
-  revisions:
-  - 5e21d7342593
-  - f8f7987586b7
-  tool_panel_section_label: Imaging
 - name: 2d_filter_segmentation_by_features
   owner: imgteam
   revisions:
@@ -175,6 +170,7 @@ tools:
   revisions:
   - 6c92ac9ce868
   - 6e65fd971e13
+  - 984358e43242
   - 9bb446db4a1e
   - b97a362ff321
   tool_panel_section_label: Imaging

--- a/imaging.yaml.lock
+++ b/imaging.yaml.lock
@@ -285,6 +285,7 @@ tools:
 - name: bfconvert
   owner: imgteam
   revisions:
+  - 10eed33aa9b2
   - b07f4839ca77
   - f3360fbeda64
   tool_panel_section_label: Imaging

--- a/imaging.yaml.lock
+++ b/imaging.yaml.lock
@@ -159,6 +159,12 @@ tools:
   - d0960e1b25a8
   - f8f1100d0701
   tool_panel_section_label: Imaging
+- name: 2d_split_binaryimage_by_watershed
+  owner: imgteam
+  revisions:
+  - 5e21d7342593
+  - f8f7987586b7
+  tool_panel_section_label: Imaging
 - name: 2d_filter_segmentation_by_features
   owner: imgteam
   revisions:


### PR DESCRIPTION
Reflects changes made by following PRs:
- https://github.com/BMCV/galaxy-image-analysis/pull/92
- https://github.com/BMCV/galaxy-image-analysis/pull/91

The tool `2d_split_binaryimage_by_watershed` is removed (functionality is now merged into the `binary2label` tool).