### PR TITLE
Add a static API

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,50 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.11'
+          architecture: 'x64'
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Build API
+        run:
+          python scripts/api.py
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          # Upload entire repository
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+import glob
+import yaml
+import json
+import os
+
+data = {}
+for fn in sorted(glob.glob("*.yaml")):
+    with open(fn, 'r') as handle:
+        tools = yaml.safe_load(handle)
+        for x in tools['tools']:
+            if 'tool_panel_section_label' in x:
+                data[f"{x['owner']}/{x['name']}"] = x['tool_panel_section_label']
+
+os.makedirs('api/', exist_ok=True)
+with open('api/labels.json', 'w') as handle:
+    json.dump(data, handle)


### PR DESCRIPTION
xref https://github.com/galaxyproject/training-material/issues/4513

```
$ cat api/labels.json | jq -S | head
{
  "althonos/gecco": "Annotation",
  "artbio/cap3": "Assembly",
  "artbio/concatenate_multiple_datasets": "Text Manipulation",
  "artbio/gsc_scran_normalize": "Single-cell",
  "artbio/manta": "Variant Calling",
  "artbio/pathifier": "Graph/Display Data",
  "astroteam/astronomical_archives": "Astronomy",
  "astroteam/astropy_fits2bitmap": "Astronomy",
  "astroteam/astropy_fits2csv": "Astronomy",
```

this assumes things only go in one section, which most sites attempt to adhere to anyway.