### PR TITLE
fix yaml to get only one section_label per tool

### DIFF
--- a/asaim.yaml
+++ b/asaim.yaml
@@ -118,7 +118,7 @@ tools:
 
   - name: 'interproscan5'
     owner: 'bgruening'
-    tool_panel_section_label: 'Metagenomic Analysis'
+    tool_panel_section_label: 'Annotation'
 
     # combination_taxo_func
   - name: 'combine_metaphlan2_humann2'
@@ -133,10 +133,10 @@ tools:
 
   - name: 'taxonomy_krona_chart'
     owner: 'crs4'
-    tool_panel_section_label: 'Graph/Display Data'
+    tool_panel_section_label: 'Metagenomic Analysis'
 
     # AMR
-    name: 'kleborate'
+  - name: 'kleborate'
     owner: 'iuc'
     tool_panel_section_label: 'Metagenomic Analysis'
 

--- a/asaim.yaml.lock
+++ b/asaim.yaml.lock
@@ -214,7 +214,7 @@ tools:
   owner: bgruening
   revisions:
   - 82547f0d3a29
-  tool_panel_section_label: Metagenomic Analysis
+  tool_panel_section_label: Annotation
 - name: combine_metaphlan2_humann2
   owner: bebatut
   revisions:

--- a/bgruening.yaml
+++ b/bgruening.yaml
@@ -273,7 +273,7 @@ tools:
 
   - name: format_cd_hit_output
     owner: bebatut
-    tool_panel_section_label: Metagenomic Analysis
+    tool_panel_section_label: Multiple Alignments
 
   - name: format_metaphlan2_output
     owner: bebatut

--- a/bgruening.yaml.lock
+++ b/bgruening.yaml.lock
@@ -909,7 +909,7 @@ tools:
   owner: bebatut
   revisions:
   - 64da677bcee2
-  tool_panel_section_label: Metagenomic Analysis
+  tool_panel_section_label: Multiple Alignments
 - name: format_metaphlan2_output
   owner: bebatut
   revisions:

--- a/cheminformatics.yaml
+++ b/cheminformatics.yaml
@@ -31,19 +31,19 @@ tools:
   - name: ctb_im_cluster_butina
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
-    
+
   - name: ctb_im_standardize
     owner: bgruening
-    tool_panel_section_label: ChemicalToolBox    
+    tool_panel_section_label: ChemicalToolBox
 
   - name: ctb_im_o3dalign
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
- 
+
   - name: ctb_im_cluster_butina_matrix
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
-  
+
   - name: traj_selections_and_merge
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox
@@ -51,18 +51,18 @@ tools:
   - name: ctb_im_constrained_conf_gen
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
-  
+
   - name: ctb_im_conformers
     owner: bgruening
-    tool_panel_section_label: ChemicalToolBox    
+    tool_panel_section_label: ChemicalToolBox
 
   - name: ctb_im_rxn_smarts_filter
     owner: bgruening
-    tool_panel_section_label: ChemicalToolBox 
+    tool_panel_section_label: ChemicalToolBox
 
   - name: ctb_im_pbf_ev
     owner: bgruening
-    tool_panel_section_label: ChemicalToolBox 
+    tool_panel_section_label: ChemicalToolBox
 
   - name: openduck_run_smd
     owner: bgruening
@@ -139,7 +139,7 @@ tools:
   - name: padel
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
-  
+
   - name: md_converter
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox
@@ -158,7 +158,7 @@ tools:
 
   - name: gmx_md
     owner: chemteam
-    tool_panel_section_label: ChemicalToolBox 
+    tool_panel_section_label: ChemicalToolBox
 
   - name: gmx_merge_topology_files
     owner: chemteam
@@ -168,11 +168,11 @@ tools:
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox
 
-  - name:  gmx_fep
+  - name: gmx_fep
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox
 
-  - name:  gmx_trj
+  - name: gmx_trj
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox
 
@@ -184,22 +184,22 @@ tools:
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox
 
-  - name:  gmx_makendx
+  - name: gmx_makendx
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox
 
-  - name:  gmx_editconf
+  - name: gmx_editconf
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox
 
-  - name:  gmx_check
+  - name: gmx_check
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox
 
-  - name:  alchemical_analysis
+  - name: alchemical_analysis
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox
-    
+
   - name: ctb_rdkit_descriptors
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
@@ -211,7 +211,7 @@ tools:
   - name: mdanalysis_angle
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox
- 
+
   - name: mdanalysis_rdf
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox
@@ -244,7 +244,7 @@ tools:
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox
 
-  - name: acpype_amber2gromacs 
+  - name: acpype_amber2gromacs
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox
 
@@ -263,12 +263,12 @@ tools:
   - name: bio3d_rmsd
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox
- 
+
   - name: bio3d_pca
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox
 
-  - name: bio3d_pca_visualize 
+  - name: bio3d_pca_visualize
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox
 
@@ -299,11 +299,11 @@ tools:
   - name: openbabel_remsmall
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
- 
+
   - name: openbabel_obgrep
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
- 
+
   - name: openbabel_change_title
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
@@ -311,31 +311,31 @@ tools:
   - name: openbabel_genprop
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
- 
+
   - name: openbabel_remions
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
- 
+
   - name: openbabel_multi_obgrep
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
-  
+
   - name: openbabel_svg_depiction
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
-  
+
   - name: openbabel_spectrophore_search
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
- 
+
   - name: openbabel_remove_protonation_state
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
- 
+
   - name: openbabel_compound_convert
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
- 
+
   - name: openbabel_subsearch
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
@@ -343,11 +343,11 @@ tools:
   - name: openbabel_filter
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
- 
+
   - name: openbabel_addh
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
- 
+
   - name: openbabel_remduplicates
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
@@ -391,15 +391,15 @@ tools:
   - name: ambertools_parmchk2
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox
- 
+
   - name: chembl
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
-    
+
   - name: chembl_structure_pipeline
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
- 
+
   - name: fpocket
     owner: bgruening
     tool_panel_section_label: ChemicalToolBox
@@ -427,11 +427,11 @@ tools:
   - name: smina
     owner: earlhaminst
     tool_panel_section_label: ChemicalToolBox
-    
+
   - name: gmx_rg
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox
-    
+
   - name: acpype_amber2gromacs
     owner: chemteam
     tool_panel_section_label: ChemicalToolBox

--- a/climate.yaml
+++ b/climate.yaml
@@ -79,11 +79,9 @@ tools:
   - name: gdal_gdaladdo
     owner: ecology
     tool_panel_section_label: 'GIS Data Handling'
-    
   - name: gdal_gdalbuildvrt
     owner: ecology
     tool_panel_section_label: 'GIS Data Handling'
-    
   - name: gdal_gdalinfo
     owner: ecology
     tool_panel_section_label: 'GIS Data Handling'
@@ -99,27 +97,23 @@ tools:
   - name: gdal_gdalwarp
     owner: ecology
     tool_panel_section_label: 'GIS Data Handling'
-    
   - name: gdal_ogr2ogr
     owner: ecology
     tool_panel_section_label: 'GIS Data Handling'
 
   - name: gdal_ogrinfo
     owner: ecology
-    tool_panel_section_label: 'GIS Data Handling'    
+    tool_panel_section_label: 'GIS Data Handling'
 
   - name: spocc_occ
     owner: ecology
     tool_panel_section_label: 'Get Data'
-    
   - name: datamash_ops
     owner: iuc
     tool_panel_section_label: 'Join, Subtract and Group'
-    
   - name: datamash_reverse
     owner: iuc
     tool_panel_section_label: 'Join, Subtract and Group'
-    
   - name: datamash_transpose
     owner: iuc
     tool_panel_section_label: 'Join, Subtract and Group'

--- a/cpt.yaml
+++ b/cpt.yaml
@@ -7,43 +7,43 @@ tools:
   - name: cpt_fasta_remove_id
     owner: cpt
     tool_panel_section_label: FASTA/FASTQ
-    
+
   - name: cpt_get_orfs
     owner: cpt
     tool_panel_section_label: Annotation
-    
+
   - name: cpt_convert_mga
     owner: cpt
     tool_panel_section_label: Convert Formats
-    
+
   - name: cpt_gff_add_parents
     owner: cpt
     tool_panel_section_label: Annotation
-    
+
   - name: cpt_fix_aragorn
     owner: cpt
     tool_panel_section_label: Convert Formats
-    
+
   - name: cpt_fix_sixpack
     owner: cpt
     tool_panel_section_label: Annotation
-    
+
   - name: cpt_shinefind
     owner: cpt
     tool_panel_section_label: Annotation
-    
+
   - name: cpt_type_filter
     owner: cpt
     tool_panel_section_label: Annotation
-    
+
   - name: cpt_req_phage_start
     owner: cpt
     tool_panel_section_label: Annotation
-    
+
   - name: cpt_remove_annotations
     owner: cpt
     tool_panel_section_label: Annotation
-    
+
   - name: cpt_prep_for_apollo
     owner: cpt
     tool_panel_section_label: Annotation
@@ -63,7 +63,7 @@ tools:
   - name: cpt_lipory
     owner: cpt
     tool_panel_section_label: Annotation
-    
+
   - name: cpt_intersect_adjacent
     owner: cpt
     tool_panel_section_label: Annotation

--- a/earlhaminst.yaml
+++ b/earlhaminst.yaml
@@ -22,7 +22,7 @@ tools:
     tool_panel_section_label: Phylogenetics
 
   - name: hcluster_sg_parser
-    owner: earlhaminst 
+    owner: earlhaminst
     tool_panel_section_label: Phylogenetics
 
   - name: t_coffee
@@ -36,11 +36,11 @@ tools:
   - name: gafa
     owner: earlhaminst
     tool_panel_section_label: Phylogenetics
-    
+
   - name: gstf_preparation
     owner: earlhaminst
     tool_panel_section_label: Phylogenetics
-   
+
   - name: ete
     owner: earlhaminst
     tool_panel_section_label: Phylogenetics
@@ -52,7 +52,7 @@ tools:
   - name: ensembl_get_feature_info
     owner: earlhaminst
     tool_panel_section_label: Get Data
-    
+
   - name: ensembl_get_genetree
     owner: earlhaminst
     tool_panel_section_label: Get Data

--- a/ecology.yaml
+++ b/ecology.yaml
@@ -6,15 +6,15 @@ tools:
   - name: pampa_presabs
     owner: ecology
     tool_panel_section_label: 'Species abundance'
-  
+
   - name: pampa_communitymetrics
     owner: ecology
     tool_panel_section_label: 'Species abundance'
-  
+
   - name: pampa_glmsp
     owner: ecology
     tool_panel_section_label: 'Species abundance'
-  
+
   - name: pampa_glmcomm
     owner: ecology
     tool_panel_section_label: 'Species abundance'
@@ -22,27 +22,27 @@ tools:
   - name: pampa_plotglm
     owner: ecology
     tool_panel_section_label: 'Species abundance'
-  
+
   - name: stoc_maketable
     owner: ecology
     tool_panel_section_label: 'Species abundance'
-    
+
   - name: stoc_filteringsp
     owner: ecology
     tool_panel_section_label: 'Species abundance'
-    
+
   - name: stoc_mainglm
     owner: ecology
     tool_panel_section_label: 'Species abundance'
-    
+
   - name: stoc_mainglm_group
     owner: ecology
     tool_panel_section_label: 'Species abundance'
- 
+
   - name: stoc_trend_indic
     owner: ecology
     tool_panel_section_label: 'Species abundance'
-    
+
   - name: regionalgam_ab_index
     owner: ecology
     tool_panel_section_label: 'Species abundance'
@@ -98,18 +98,18 @@ tools:
   - name: cb_div
     owner: ecology
     tool_panel_section_label: 'Biodiversity data exploration'
-    
+
   - name: cb_dissim
     owner: ecology
-    tool_panel_section_label: 'Biodiversity data exploration'
-  
+    tool_panel_section_label: 'Compute indicators for turnover boulders fields'
+
   - name: cb_ivr
     owner: ecology
-    tool_panel_section_label: 'Biodiversity data exploration'
+    tool_panel_section_label: 'Compute indicators for turnover boulders fields'
 
   - name: sample_seqs
     owner: peterjc
-    tool_panel_section_label: 'Filter and Sort'
+    tool_panel_section_label: 'NCBI Blast'
 
   - name: xmlstarlet
     owner: ecology
@@ -145,7 +145,7 @@ tools:
 
   - name: prinseq
     owner: iuc
-    tool_panel_section_label: 'Text Manipulation'
+    tool_panel_section_label: 'FASTA/FASTQ'
 
 
   - name: split_file_on_column
@@ -175,7 +175,7 @@ tools:
 
   - name: subtract
     owner: devteam
-    tool_panel_section_label: 'Text Manipulation'
+    tool_panel_section_label: 'Operate on Genomic Intervals'
 
   - name: subtract_query
     owner: devteam
@@ -211,7 +211,7 @@ tools:
 
   - name: cluster
     owner: devteam
-    tool_panel_section_label: 'Text Manipulation'
+    tool_panel_section_label: 'Operate on Genomic Intervals'
 
   - name: get_flanks
     owner: devteam
@@ -219,11 +219,11 @@ tools:
 
   - name: complement
     owner: devteam
-    tool_panel_section_label: 'Text Manipulation'
+    tool_panel_section_label: 'Operate on Genomic Intervals'
 
   - name: basecoverage
     owner: devteam
-    tool_panel_section_label: 'Text Manipulation'
+    tool_panel_section_label: 'Operate on Genomic Intervals'
 
   - name: dna_filtering
     owner: devteam
@@ -642,7 +642,7 @@ tools:
   - name: xarray_metadata_info
     owner: ecology
     tool_panel_section_label: 'GIS Data Handling'
-    
+
   - name: xarray_select
     owner: ecology
     tool_panel_section_label: 'GIS Data Handling'
@@ -725,43 +725,43 @@ tools:
   - name: vigiechiro_idvalid
     owner: ecology
     tool_panel_section_label: 'Animal Detection on Acoustic Recordings'
-    
+
   - name: cb_dissim
     owner: ecology
     tool_panel_section_label: 'Compute indicators for turnover boulders fields'
-  
+
   - name: cb_ivr
     owner: ecology
     tool_panel_section_label: 'Compute indicators for turnover boulders fields'
- 
+
   - name: champ_blocs
     owner: ecology
     tool_panel_section_label: 'Compute indicators for turnover boulders fields'
-    
+
   - name: srs_preprocess_s2
     owner: ecology
     tool_panel_section_label: 'Compute indicators for satellite remote sensing'
-    
+
   - name: srs_diversity_maps
     owner: ecology
     tool_panel_section_label: 'Compute indicators for satellite remote sensing'
-    
+
   - name: srs_global_indices
     owner: ecology
     tool_panel_section_label: 'Compute indicators for satellite remote sensing'
-    
+
   - name: srs_process_data
     owner: ecology
     tool_panel_section_label: 'Compute indicators for satellite remote sensing'
-    
+
   - name: srs_spectral_indices
     owner: ecology
     tool_panel_section_label: 'Compute indicators for satellite remote sensing'
-    
+
   - name: srs_pca
     owner: ecology
     tool_panel_section_label: 'Compute indicators for satellite remote sensing'
-    
+
   - name: srs_metadata
     owner: ecology
     tool_panel_section_label: 'GIS Data Handling'
@@ -769,11 +769,11 @@ tools:
   - name: obisindicators
     owner: ecology
     tool_panel_section_label: 'Biodiversity data exploration'
-    
+
   - name: ab1_fastq_converter
     owner: ecology
     tool_panel_section_label: 'Convert Formats'
-    
+
   - name: aligned_to_consensus
     owner: ecology
     tool_panel_section_label: 'Assembly'
@@ -793,7 +793,7 @@ tools:
   - name: ecoregion_taxa_seeker
     owner: ecology
     tool_panel_section_label: 'Ecoregionalization'
-   
+
   - name: ecoregion_eco_map
     owner: ecology
     tool_panel_section_label: 'Ecoregionalization'

--- a/ecology.yaml
+++ b/ecology.yaml
@@ -109,7 +109,7 @@ tools:
 
   - name: sample_seqs
     owner: peterjc
-    tool_panel_section_label: 'NCBI Blast'
+    tool_panel_section_label: 'Filter and Sort'
 
   - name: xmlstarlet
     owner: ecology

--- a/ecology.yaml.lock
+++ b/ecology.yaml.lock
@@ -147,19 +147,19 @@ tools:
   - 7e6cc3da1189
   - 8dc082da41c1
   - ffaa9a71b2d2
-  tool_panel_section_label: Biodiversity data exploration
+  tool_panel_section_label: Compute indicators for turnover boulders fields
 - name: cb_ivr
   owner: ecology
   revisions:
   - 8c6142630659
   - b67730406f1b
   - bcbad4f83dec
-  tool_panel_section_label: Biodiversity data exploration
+  tool_panel_section_label: Compute indicators for turnover boulders fields
 - name: sample_seqs
   owner: peterjc
   revisions:
   - 7c40a1fbc82e
-  tool_panel_section_label: Filter and Sort
+  tool_panel_section_label: NCBI Blast
 - name: xmlstarlet
   owner: ecology
   revisions:
@@ -227,7 +227,7 @@ tools:
   - 02befcb391f5
   - 1ee282794de3
   - 654b3a274ed5
-  tool_panel_section_label: Text Manipulation
+  tool_panel_section_label: FASTA/FASTQ
 - name: split_file_on_column
   owner: bgruening
   revisions:
@@ -271,7 +271,7 @@ tools:
   revisions:
   - 0145969324c4
   - 0427ca314f3d
-  tool_panel_section_label: Text Manipulation
+  tool_panel_section_label: Operate on Genomic Intervals
 - name: subtract_query
   owner: devteam
   revisions:
@@ -319,7 +319,7 @@ tools:
   revisions:
   - 05696474ee89
   - a126ec6ea0e4
-  tool_panel_section_label: Text Manipulation
+  tool_panel_section_label: Operate on Genomic Intervals
 - name: get_flanks
   owner: devteam
   revisions:
@@ -330,13 +330,13 @@ tools:
   revisions:
   - 38c8bb402872
   - 8b6c6ec55c6e
-  tool_panel_section_label: Text Manipulation
+  tool_panel_section_label: Operate on Genomic Intervals
 - name: basecoverage
   owner: devteam
   revisions:
   - 2cedec3759e4
   - 9c5ff4695c97
-  tool_panel_section_label: Text Manipulation
+  tool_panel_section_label: Operate on Genomic Intervals
 - name: dna_filtering
   owner: devteam
   revisions:

--- a/ecology.yaml.lock
+++ b/ecology.yaml.lock
@@ -159,7 +159,7 @@ tools:
   owner: peterjc
   revisions:
   - 7c40a1fbc82e
-  tool_panel_section_label: NCBI Blast
+  tool_panel_section_label: Filter and Sort
 - name: xmlstarlet
   owner: ecology
   revisions:

--- a/eirene.yaml
+++ b/eirene.yaml
@@ -66,39 +66,39 @@ tools:
   - name: matchms_convert
     owner: recetox
     tool_panel_section_label: Metabolomics
-    
+
   - name: matchms_filtering
     owner: recetox
     tool_panel_section_label: Metabolomics
-    
+
   - name: matchms_fingerprint_similarity
     owner: recetox
     tool_panel_section_label: Metabolomics
-    
+
   - name: matchms_formatter
     owner: recetox
     tool_panel_section_label: Metabolomics
-    
+
   - name: matchms_metadata_export
     owner: recetox
     tool_panel_section_label: Metabolomics
-    
+
   - name: matchms_metadata_match
     owner: recetox
     tool_panel_section_label: Metabolomics
-    
+
   - name: matchms_networking
     owner: recetox
     tool_panel_section_label: Metabolomics
-    
+
   - name: matchms_similarity
     owner: recetox
     tool_panel_section_label: Metabolomics
-    
+
   - name: matchms_spectral_similarity
     owner: recetox
     tool_panel_section_label: Metabolomics
-    
+
   - name: matchms_split
     owner: recetox
     tool_panel_section_label: Metabolomics

--- a/europe-custom.yaml
+++ b/europe-custom.yaml
@@ -78,7 +78,7 @@ tools:
 
   - name: taxonomy_krona_chart
     owner: crs4
-    tool_panel_section_label: NCBI Blast
+    tool_panel_section_label: Metagenomic Analysis
 
   - name: text_processing
     owner: bgruening
@@ -110,7 +110,7 @@ tools:
     tool_panel_section_label: Get Data
   - name: prinseq
     owner: iuc
-    tool_panel_section_label: Text Manipulation
+    tool_panel_section_label: FASTA/FASTQ
   - name: add_value
     owner: devteam
     tool_panel_section_label: Text Manipulation
@@ -149,19 +149,19 @@ tools:
     tool_panel_section_label: Text Manipulation
   - name: cluster
     owner: devteam
-    tool_panel_section_label: Text Manipulation
+    tool_panel_section_label: Operate on Genomic Intervals
   - name: get_flanks
     owner: devteam
     tool_panel_section_label: Text Manipulation
   - name: complement
     owner: devteam
-    tool_panel_section_label: Text Manipulation
+    tool_panel_section_label: Operate on Genomic Intervals
   - name: subtract
     owner: devteam
-    tool_panel_section_label: Text Manipulation
+    tool_panel_section_label: Operate on Genomic Intervals
   - name: basecoverage
     owner: devteam
-    tool_panel_section_label: Text Manipulation
+    tool_panel_section_label: Operate on Genomic Intervals
   - name: subtract_query
     owner: devteam
     tool_panel_section_label: Text Manipulation
@@ -185,21 +185,21 @@ tools:
     tool_panel_section_label: Filter and Sort
   - name: sample_seqs
     owner: peterjc
-    tool_panel_section_label: Filter and Sort
+    tool_panel_section_label: NCBI Blast
   - name: collection_column_join
     owner: iuc
     tool_panel_section_label: Join, Subtract and Group
 
-  # - install_repository_dependencies: true
-  #   install_resolver_dependencies: true
-  #   install_tool_dependencies: false
-  #   name: datamash_wrapper
-  #   owner: agordon
-  #   tool_panel_section_label: Join, Subtract and Group
+    # - install_repository_dependencies: true
+    #   install_resolver_dependencies: true
+    #   install_tool_dependencies: false
+    #   name: datamash_wrapper
+    #   owner: agordon
+    #   tool_panel_section_label: Join, Subtract and Group
 
   - name: subtract
     owner: devteam
-    tool_panel_section_label: Join, Subtract and Group
+    tool_panel_section_label: Operate on Genomic Intervals
 
   - name: bam_to_scidx
     owner: iuc
@@ -323,7 +323,7 @@ tools:
     tool_panel_section_label: Regional Variation
   - name: draw_stacked_barplots
     owner: devteam
-    tool_panel_section_label: Regional Variation
+    tool_panel_section_label: Graph/Display Data
   - name: delete_overlapping_indels
     owner: devteam
     tool_panel_section_label: Regional Variation
@@ -819,10 +819,10 @@ tools:
     tool_panel_section_label: Peak Calling
   - name: pileometh
     owner: bgruening
-    tool_panel_section_label: Epigenetics
+    tool_panel_section_label: Peak Calling
   - name: bwameth
     owner: iuc
-    tool_panel_section_label: Epigenetics
+    tool_panel_section_label: Mapping
   - name: metilene
     owner: rnateam
     tool_panel_section_label: Epigenetics
@@ -876,7 +876,7 @@ tools:
     tool_panel_section_label: Annotation
   - name: hammock
     owner: hammock
-    tool_panel_section_label: Annotation
+    tool_panel_section_label: Multiple Alignments
   - name: segmentation_fold
     owner: yhoogstrate
     tool_panel_section_label: Annotation
@@ -999,7 +999,7 @@ tools:
     tool_panel_section_label: ChemicalToolBox
   - name: hifive
     owner: sauria
-    tool_panel_section_label: Test Tools
+    tool_panel_section_label: Epigenetics
   - name: translate_bed_sequences
     owner: jjohnson
     tool_panel_section_label: Operate on Genomic Intervals
@@ -1017,31 +1017,31 @@ tools:
     tool_panel_section_label: EMBOSS
   - name: kraken_taxonomy_report
     owner: iuc
-    tool_panel_section_label: NCBI Blast
+    tool_panel_section_label: Metagenomic Analysis
   - name: ncbi_blast_plus
     owner: devteam
     tool_panel_section_label: NCBI Blast
   - name: kraken2tax
     owner: devteam
-    tool_panel_section_label: NCBI Blast
+    tool_panel_section_label: Metagenomic Analysis
   - name: kraken
     owner: devteam
-    tool_panel_section_label: NCBI Blast
+    tool_panel_section_label: Metagenomic Analysis
   - name: blast_rbh
     owner: peterjc
     tool_panel_section_label: NCBI Blast
   - name: kraken_report
     owner: devteam
-    tool_panel_section_label: NCBI Blast
+    tool_panel_section_label: Metagenomic Analysis
   - name: taxonomy_krona_chart
     owner: crs4
-    tool_panel_section_label: NCBI Blast
+    tool_panel_section_label: Metagenomic Analysis
   - name: kraken_filter
     owner: devteam
-    tool_panel_section_label: NCBI Blast
+    tool_panel_section_label: Metagenomic Analysis
   - name: kraken_translate
     owner: devteam
-    tool_panel_section_label: NCBI Blast
+    tool_panel_section_label: Metagenomic Analysis
   - name: sample_seqs
     owner: peterjc
     tool_panel_section_label: NCBI Blast

--- a/europe-custom.yaml
+++ b/europe-custom.yaml
@@ -185,7 +185,7 @@ tools:
     tool_panel_section_label: Filter and Sort
   - name: sample_seqs
     owner: peterjc
-    tool_panel_section_label: NCBI Blast
+    tool_panel_section_label: Filter and Sort
   - name: collection_column_join
     owner: iuc
     tool_panel_section_label: Join, Subtract and Group
@@ -1044,7 +1044,7 @@ tools:
     tool_panel_section_label: Metagenomic Analysis
   - name: sample_seqs
     owner: peterjc
-    tool_panel_section_label: NCBI Blast
+    tool_panel_section_label: Filter and Sort
   - name: diamond
     owner: bgruening
     tool_panel_section_label: NCBI Blast

--- a/europe-custom.yaml.lock
+++ b/europe-custom.yaml.lock
@@ -111,7 +111,7 @@ tools:
   owner: crs4
   revisions:
   - 020b3087d0b7
-  tool_panel_section_label: NCBI Blast
+  tool_panel_section_label: Metagenomic Analysis
 - name: text_processing
   owner: bgruening
   revisions:
@@ -176,7 +176,7 @@ tools:
   - 1ee282794de3
   - 654b3a274ed5
   - 6b865dde1baa
-  tool_panel_section_label: Text Manipulation
+  tool_panel_section_label: FASTA/FASTQ
 - name: add_value
   owner: devteam
   revisions:
@@ -241,7 +241,7 @@ tools:
   owner: devteam
   revisions:
   - 765ceb06c3e2
-  tool_panel_section_label: Text Manipulation
+  tool_panel_section_label: Operate on Genomic Intervals
 - name: get_flanks
   owner: devteam
   revisions:
@@ -251,17 +251,17 @@ tools:
   owner: devteam
   revisions:
   - e0a23ab32d7f
-  tool_panel_section_label: Text Manipulation
+  tool_panel_section_label: Operate on Genomic Intervals
 - name: subtract
   owner: devteam
   revisions:
   - 7a2a604ae9c8
-  tool_panel_section_label: Text Manipulation
+  tool_panel_section_label: Operate on Genomic Intervals
 - name: basecoverage
   owner: devteam
   revisions:
   - 0a3e3133b09d
-  tool_panel_section_label: Text Manipulation
+  tool_panel_section_label: Operate on Genomic Intervals
 - name: subtract_query
   owner: devteam
   revisions:
@@ -301,7 +301,7 @@ tools:
   owner: peterjc
   revisions:
   - 02c13ef1a669
-  tool_panel_section_label: Filter and Sort
+  tool_panel_section_label: NCBI Blast
 - name: collection_column_join
   owner: iuc
   revisions:
@@ -315,7 +315,7 @@ tools:
   owner: devteam
   revisions:
   - 7a2a604ae9c8
-  tool_panel_section_label: Join, Subtract and Group
+  tool_panel_section_label: Operate on Genomic Intervals
 - name: bam_to_scidx
   owner: iuc
   revisions:
@@ -553,7 +553,7 @@ tools:
   owner: devteam
   revisions:
   - e997b710e38a
-  tool_panel_section_label: Regional Variation
+  tool_panel_section_label: Graph/Display Data
 - name: delete_overlapping_indels
   owner: devteam
   revisions:
@@ -1508,7 +1508,7 @@ tools:
   owner: bgruening
   revisions:
   - ccc755bdf11d
-  tool_panel_section_label: Epigenetics
+  tool_panel_section_label: Peak Calling
 - name: bwameth
   owner: iuc
   revisions:
@@ -1520,7 +1520,7 @@ tools:
   - b4e6819b25ef
   - d82648ad25a3
   - f7094efef903
-  tool_panel_section_label: Epigenetics
+  tool_panel_section_label: Mapping
 - name: metilene
   owner: rnateam
   revisions:
@@ -1623,7 +1623,7 @@ tools:
   owner: hammock
   revisions:
   - 4db310b7e37c
-  tool_panel_section_label: Annotation
+  tool_panel_section_label: Multiple Alignments
 - name: segmentation_fold
   owner: yhoogstrate
   revisions:
@@ -1849,7 +1849,7 @@ tools:
   owner: sauria
   revisions:
   - 4a978cf8cf92
-  tool_panel_section_label: Test Tools
+  tool_panel_section_label: Epigenetics
 - name: translate_bed_sequences
   owner: jjohnson
   revisions:
@@ -1882,7 +1882,7 @@ tools:
   - 3f1a0d47ea8d
   - b11b3ac48bb9
   - b97694b21bc3
-  tool_panel_section_label: NCBI Blast
+  tool_panel_section_label: Metagenomic Analysis
 - name: ncbi_blast_plus
   owner: devteam
   revisions:
@@ -1892,12 +1892,12 @@ tools:
   owner: devteam
   revisions:
   - f03c7ba8d8bc
-  tool_panel_section_label: NCBI Blast
+  tool_panel_section_label: Metagenomic Analysis
 - name: kraken
   owner: devteam
   revisions:
   - b2392a9dfb01
-  tool_panel_section_label: NCBI Blast
+  tool_panel_section_label: Metagenomic Analysis
 - name: blast_rbh
   owner: peterjc
   revisions:
@@ -1907,22 +1907,22 @@ tools:
   owner: devteam
   revisions:
   - 9ae975c30dde
-  tool_panel_section_label: NCBI Blast
+  tool_panel_section_label: Metagenomic Analysis
 - name: taxonomy_krona_chart
   owner: crs4
   revisions:
   - 020b3087d0b7
-  tool_panel_section_label: NCBI Blast
+  tool_panel_section_label: Metagenomic Analysis
 - name: kraken_filter
   owner: devteam
   revisions:
   - fe94f318048c
-  tool_panel_section_label: NCBI Blast
+  tool_panel_section_label: Metagenomic Analysis
 - name: kraken_translate
   owner: devteam
   revisions:
   - b9971bca4b01
-  tool_panel_section_label: NCBI Blast
+  tool_panel_section_label: Metagenomic Analysis
 - name: sample_seqs
   owner: peterjc
   revisions:

--- a/europe-custom.yaml.lock
+++ b/europe-custom.yaml.lock
@@ -301,7 +301,7 @@ tools:
   owner: peterjc
   revisions:
   - 02c13ef1a669
-  tool_panel_section_label: NCBI Blast
+  tool_panel_section_label: Filter and Sort
 - name: collection_column_join
   owner: iuc
   revisions:
@@ -1927,7 +1927,7 @@ tools:
   owner: peterjc
   revisions:
   - 02c13ef1a669
-  tool_panel_section_label: NCBI Blast
+  tool_panel_section_label: Filter and Sort
 - name: diamond
   owner: bgruening
   revisions:

--- a/galaxy-australia.yaml
+++ b/galaxy-australia.yaml
@@ -9,8 +9,8 @@ tools:
 
   - name: cactus_cactus
     owner: galaxy-australia
-    tool_panel_section_label: Assembly  
-  
+    tool_panel_section_label: Assembly
+
   - name: cactus_export
     owner: galaxy-australia
     tool_panel_section_label: Assembly

--- a/goeckslab.yaml
+++ b/goeckslab.yaml
@@ -15,7 +15,7 @@ tools:
 
   - name: mesmer
     owner: goeckslab
-    tool_panel_section_label: Imaging
+    tool_panel_section_label: Spatial Omics
 
   - name: squidpy
     owner: goeckslab

--- a/goeckslab.yaml.lock
+++ b/goeckslab.yaml.lock
@@ -18,7 +18,7 @@ tools:
   - 02abff468d60
   - 187918c47051
   - 53240d7c1fc5
-  tool_panel_section_label: Imaging
+  tool_panel_section_label: Spatial Omics
 - name: squidpy
   owner: goeckslab
   revisions:

--- a/imaging.yaml
+++ b/imaging.yaml
@@ -35,15 +35,15 @@ tools:
   - name: 2d_local_threshold
     owner: imgteam
     tool_panel_section_label: "Imaging"
-    
+
   - name: segmetrics
     owner: imgteam
     tool_panel_section_label: "Imaging"
-    
+
   - name: superdsm
     owner: imgteam
     tool_panel_section_label: "Imaging"
-    
+
   - name: rfove
     owner: imgteam
     tool_panel_section_label: "Imaging"
@@ -51,15 +51,15 @@ tools:
   - name: landmark_registration
     owner: imgteam
     tool_panel_section_label: "Imaging"
-    
+
   - name: landmark_registration_ls
     owner: imgteam
     tool_panel_section_label: "Imaging"
-    
+
   - name: image_registration_affine
     owner: imgteam
     tool_panel_section_label: "Imaging"
-    
+
   - name: projective_transformation
     owner: imgteam
     tool_panel_section_label: "Imaging"
@@ -67,19 +67,19 @@ tools:
   - name: projective_transformation_points
     owner: imgteam
     tool_panel_section_label: "Imaging"
-    
+
   - name: spot_detection_2d
     owner: imgteam
     tool_panel_section_label: "Imaging"
-    
+
   - name: points_association_nn
     owner: imgteam
     tool_panel_section_label: "Imaging"
-    
+
   - name: curve_fitting
     owner: imgteam
     tool_panel_section_label: "Imaging"
-    
+
   - name: imagecoordinates_flipaxis
     owner: imgteam
     tool_panel_section_label: "Imaging"
@@ -87,7 +87,7 @@ tools:
   - name: 2d_split_binaryimage_by_watershed
     owner: imgteam
     tool_panel_section_label: "Imaging"
-    
+
   - name: 2d_filter_segmentation_by_features
     owner: imgteam
     tool_panel_section_label: "Imaging"
@@ -119,23 +119,23 @@ tools:
   - name: concat_channels
     owner: imgteam
     tool_panel_section_label: "Imaging"
-    
+
   - name: points2binaryimage
     owner: imgteam
     tool_panel_section_label: "Imaging"
-    
+
   - name: points2labelimage
     owner: imgteam
     tool_panel_section_label: "Imaging"
-    
+
   - name: labelimage2points
     owner: imgteam
     tool_panel_section_label: "Imaging"
-    
+
   - name: permutate_axis
     owner: imgteam
     tool_panel_section_label: "Imaging"
-  
+
   - name: mahotas_features
     owner: imgteam
     tool_panel_section_label: "Imaging"
@@ -143,11 +143,11 @@ tools:
   - name: 2d_feature_extraction
     owner: imgteam
     tool_panel_section_label: "Imaging"
-    
+
   - name: count_objects
     owner: imgteam
     tool_panel_section_label: "Imaging"
-    
+
   - name: coordinates_of_roi
     owner: imgteam
     tool_panel_section_label: "Imaging"
@@ -175,7 +175,7 @@ tools:
   - name: visceral_evaluatesegmentation
     owner: imgteam
     tool_panel_section_label: "Imaging"
-  
+
   - name: bfconvert
     owner: imgteam
     tool_panel_section_label: "Imaging"
@@ -291,7 +291,7 @@ tools:
   - name: imagej2_bunwarpj_adapt_transform
     owner: imgteam
     tool_panel_section_label: "Imaging"
-    
+
   - name: unzip
     owner: imgteam
     tool_panel_section_label: 'Collection Operations'
@@ -303,91 +303,85 @@ tools:
   - name: cp_cellprofiler
     owner: bgruening
     tool_panel_section_label: "Imaging"
-    
+
   - name: cp_common
     owner: bgruening
-    tool_panel_section_label: "Imaging"    
+    tool_panel_section_label: "Imaging"
 
   - name: cp_color_to_gray
     owner: bgruening
-    tool_panel_section_label: "Imaging"    
+    tool_panel_section_label: "Imaging"
 
   - name: cp_tile
     owner: bgruening
-    tool_panel_section_label: "Imaging"    
+    tool_panel_section_label: "Imaging"
 
   - name: cp_track_objects
     owner: bgruening
-    tool_panel_section_label: "Imaging"    
+    tool_panel_section_label: "Imaging"
 
   - name: cp_overlay_outlines
     owner: bgruening
-    tool_panel_section_label: "Imaging"    
+    tool_panel_section_label: "Imaging"
 
   - name: cp_convert_objects_to_image
     owner: bgruening
     tool_panel_section_label: "Imaging"
-    
+
   - name: cp_display_data_on_image
     owner: bgruening
     tool_panel_section_label: "Imaging"
-    
+
   - name: cp_enhance_or_suppress_features
     owner: bgruening
     tool_panel_section_label: "Imaging"
-    
+
   - name: cp_export_to_spreadsheet
     owner: bgruening
     tool_panel_section_label: "Imaging"
-    
+
   - name: cp_gray_to_color
     owner: bgruening
     tool_panel_section_label: "Imaging"
-    
+
   - name: cp_identify_primary_objects
     owner: bgruening
-    tool_panel_section_label: "Imaging"  
-    
+    tool_panel_section_label: "Imaging"
   - name: cp_mask_image
     owner: bgruening
-    tool_panel_section_label: "Imaging"      
-    
+    tool_panel_section_label: "Imaging"
   - name: cp_measure_granularity
     owner: bgruening
     tool_panel_section_label: "Imaging"
-    
+
   - name: cp_measure_image_area_occupied
     owner: bgruening
-    tool_panel_section_label: "Imaging"  
-    
+    tool_panel_section_label: "Imaging"
   - name: cp_measure_image_intensity
     owner: bgruening
-    tool_panel_section_label: "Imaging"  
-    
+    tool_panel_section_label: "Imaging"
   - name: cp_measure_image_quality
     owner: bgruening
-    tool_panel_section_label: "Imaging"  
-    
+    tool_panel_section_label: "Imaging"
   - name: cp_measure_object_intensity
     owner: bgruening
-    tool_panel_section_label: "Imaging"  
-  
+    tool_panel_section_label: "Imaging"
   - name: cp_measure_object_size_shape
     owner: bgruening
     tool_panel_section_label: "Imaging"
-    
+
   - name: cp_measure_texture
     owner: bgruening
     tool_panel_section_label: "Imaging"
-    
+
   - name: cp_relate_objects
     owner: bgruening
     tool_panel_section_label: "Imaging"
-    
+
   - name: cp_save_images
     owner: bgruening
     tool_panel_section_label: "Imaging"
-    
+
   - name: cp_image_math
     owner: bgruening
     tool_panel_section_label: "Imaging"

--- a/metabolomics.yaml
+++ b/metabolomics.yaml
@@ -52,7 +52,7 @@ tools:
   - name: camera_combinexsannos
     owner: mmonsoor
     tool_panel_section_label: Metabolomics
-    
+
   - name: mspurity_flagremove
     owner: computational-metabolomics
     tool_panel_section_label: Metabolomics
@@ -81,11 +81,11 @@ tools:
   - name: mspurity_createmsp
     owner: computational-metabolomics
     tool_panel_section_label: Metabolomics
-   
+
   - name: mspurity_dimspredictpuritysingle
     owner: computational-metabolomics
     tool_panel_section_label: Metabolomics
-  
+
   - name: mspurity_purityx
     owner: computational-metabolomics
     tool_panel_section_label: Metabolomics
@@ -168,7 +168,7 @@ tools:
 
   - name: transformation
     owner: ethevenot
-    tool_panel_section_label: Metabolomics
+    tool_panel_section_label: Statistics
 
   - name: qualitymetrics
     owner: ethevenot
@@ -183,15 +183,15 @@ tools:
 ## ALL
   - name: univariate
     owner: ethevenot
-    tool_panel_section_label: Metabolomics
+    tool_panel_section_label: Statistics
 
   - name: multivariate
     owner: ethevenot
-    tool_panel_section_label: Metabolomics
+    tool_panel_section_label: Statistics
 
   - name: anova
     owner: lecorguille
-    tool_panel_section_label: Metabolomics
+    tool_panel_section_label: Statistics
 
   - name: mixmodel4repeated_measures
     owner: jfrancoismartin
@@ -203,7 +203,7 @@ tools:
 
   - name: biosigner
     owner: ethevenot
-    tool_panel_section_label: Metabolomics
+    tool_panel_section_label: Statistics
 
   - name: corr_table
     owner: melpetera
@@ -211,7 +211,7 @@ tools:
 
   - name: heatmap
     owner: ethevenot
-    tool_panel_section_label: Metabolomics
+    tool_panel_section_label: Statistics
 
 
 # annotation
@@ -234,7 +234,7 @@ tools:
 
   - name: lcmsmatching
     owner: prog
-    tool_panel_section_label: Metabolomics
+    tool_panel_section_label: Annotation
 
 ## LCMS
 #  - name: probmetab
@@ -250,7 +250,7 @@ tools:
   - name: mspurity_spectralmatching
     owner: computational-metabolomics
     tool_panel_section_label: Metabolomics
-    
+
   - name: metfrag
     owner: computational-metabolomics
     tool_panel_section_label: Metabolomics
@@ -309,15 +309,15 @@ tools:
 
   - name: msconvert
     owner: galaxyp
-    tool_panel_section_label: Metabolomics
+    tool_panel_section_label: Convert Formats
 
   - name: thermo_raw_file_converter
     owner: galaxyp
-    tool_panel_section_label: Metabolomics
+    tool_panel_section_label: Convert Formats
 
   - name: msms_extractor
     owner: galaxyp
-    tool_panel_section_label: Metabolomics
+    tool_panel_section_label: Convert Formats
 
 
   - name: isoplot

--- a/metabolomics.yaml.lock
+++ b/metabolomics.yaml.lock
@@ -223,7 +223,7 @@ tools:
   owner: ethevenot
   revisions:
   - cc0e9eff0de2
-  tool_panel_section_label: Metabolomics
+  tool_panel_section_label: Statistics
 - name: qualitymetrics
   owner: ethevenot
   revisions:
@@ -240,18 +240,18 @@ tools:
   revisions:
   - 140290de7986
   - 5687435b182c
-  tool_panel_section_label: Metabolomics
+  tool_panel_section_label: Statistics
 - name: multivariate
   owner: ethevenot
   revisions:
   - 5526f8258e8a
   - e91de3b04320
-  tool_panel_section_label: Metabolomics
+  tool_panel_section_label: Statistics
 - name: anova
   owner: lecorguille
   revisions:
   - 102049093b7d
-  tool_panel_section_label: Metabolomics
+  tool_panel_section_label: Statistics
 - name: mixmodel4repeated_measures
   owner: jfrancoismartin
   revisions:
@@ -267,7 +267,7 @@ tools:
   revisions:
   - b2414be87d4b
   - fa80bd02055f
-  tool_panel_section_label: Metabolomics
+  tool_panel_section_label: Statistics
 - name: corr_table
   owner: melpetera
   revisions:
@@ -277,7 +277,7 @@ tools:
   owner: ethevenot
   revisions:
   - b1667c118127
-  tool_panel_section_label: Metabolomics
+  tool_panel_section_label: Statistics
 - name: hmdb_ms_search
   owner: fgiacomoni
   revisions:
@@ -304,7 +304,7 @@ tools:
   revisions:
   - f86fec07f392
   - fb9c0409d85c
-  tool_panel_section_label: Metabolomics
+  tool_panel_section_label: Annotation
 - name: golm_ws_lib_search
   owner: fgiacomoni
   revisions:
@@ -398,17 +398,17 @@ tools:
   revisions:
   - 6153e8ada1ee
   - 9ec469ff191a
-  tool_panel_section_label: Metabolomics
+  tool_panel_section_label: Convert Formats
 - name: thermo_raw_file_converter
   owner: galaxyp
   revisions:
   - 77a18a61aeed
-  tool_panel_section_label: Metabolomics
+  tool_panel_section_label: Convert Formats
 - name: msms_extractor
   owner: galaxyp
   revisions:
   - 4bef80b09854
-  tool_panel_section_label: Metabolomics
+  tool_panel_section_label: Convert Formats
 - name: isoplot
   owner: workflow4metabolomics
   revisions:

--- a/peterjc.yaml
+++ b/peterjc.yaml
@@ -10,7 +10,7 @@ tools:
 
   - name: sample_seqs
     owner: peterjc
-    tool_panel_section_label: 'NCBI Blast'
+    tool_panel_section_label: 'Filter and Sort'
 
   - name: seq_filter_by_id
     owner: peterjc

--- a/peterjc.yaml
+++ b/peterjc.yaml
@@ -10,8 +10,8 @@ tools:
 
   - name: sample_seqs
     owner: peterjc
-    tool_panel_section_label: 'Filter and Sort'
-   
+    tool_panel_section_label: 'NCBI Blast'
+
   - name: seq_filter_by_id
     owner: peterjc
     tool_panel_section_label: 'Filter and Sort'

--- a/peterjc.yaml.lock
+++ b/peterjc.yaml.lock
@@ -11,7 +11,7 @@ tools:
   owner: peterjc
   revisions:
   - 7c40a1fbc82e
-  tool_panel_section_label: Filter and Sort
+  tool_panel_section_label: NCBI Blast
 - name: seq_filter_by_id
   owner: peterjc
   revisions:

--- a/peterjc.yaml.lock
+++ b/peterjc.yaml.lock
@@ -11,7 +11,7 @@ tools:
   owner: peterjc
   revisions:
   - 7c40a1fbc82e
-  tool_panel_section_label: NCBI Blast
+  tool_panel_section_label: Filter and Sort
 - name: seq_filter_by_id
   owner: peterjc
   revisions:

--- a/rnateam.yaml
+++ b/rnateam.yaml
@@ -38,48 +38,48 @@ tools:
 
   - name: cmv
     owner: rnateam
-    tool_panel_section_label: RNA Analysis 
-    
+    tool_panel_section_label: RNA Analysis
+
   - name: rnalien
     owner: rnateam
-    tool_panel_section_label: RNA Analysis 
+    tool_panel_section_label: RNA Analysis
 
   - name: selectsequencesfrommsa
     owner: rnateam
-    tool_panel_section_label: RNA Analysis 
+    tool_panel_section_label: RNA Analysis
 
   - name: locarna_multiple
     owner: rnateam
-    tool_panel_section_label: RNA Analysis 
+    tool_panel_section_label: RNA Analysis
 
   - name: fuma
     owner: yhoogstrate
-    tool_panel_section_label: RNA Analysis 
-    
+    tool_panel_section_label: RNA Analysis
+
   - name: infernal
     owner: bgruening
-    tool_panel_section_label: RNA Analysis 
-    
+    tool_panel_section_label: RNA Analysis
+
   - name: aresite2
     owner: rnateam
-    tool_panel_section_label: RNA Analysis  
-    
+    tool_panel_section_label: RNA Analysis
+
   - name: targetfinder
     owner: rnateam
-    tool_panel_section_label: RNA Analysis  
-    
+    tool_panel_section_label: RNA Analysis
+
   - name: flaimapper
     owner: yhoogstrate
-    tool_panel_section_label: RNA Analysis  
-    
+    tool_panel_section_label: RNA Analysis
+
   - name: nastiseq
     owner: rnateam
-    tool_panel_section_label: RNA Analysis  
-    
+    tool_panel_section_label: RNA Analysis
+
   - name: pipmir
     owner: rnateam
     tool_panel_section_label: RNA Analysis
-    
+
   - name: ribotaper
     owner: rnateam
     tool_panel_section_label: RNA Analysis
@@ -115,7 +115,7 @@ tools:
   - name: rnaz_randomize_aln
     owner: bgruening
     tool_panel_section_label: RNA Analysis
- 
+
   - name: rnaz_annotate
     owner: bgruening
     tool_panel_section_label: RNA Analysis
@@ -131,7 +131,7 @@ tools:
   - name: htseq_clip
     owner: rnateam
     tool_panel_section_label: Peak Calling
-    
+
   - name: peakachu
     owner: rnateam
     tool_panel_section_label: Peak Calling

--- a/single-cell-ebi-gxa.yaml
+++ b/single-cell-ebi-gxa.yaml
@@ -7,131 +7,131 @@ tools:
   - name: dropletutils_read_10x
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_utils_viz'
-    
+
   - name: dropletutils_empty_drops
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_utils_viz'
-    
+
   - name: gtf2gene_list
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_utils_viz'
-    
+
   - name: retrieve_scxa
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_get-scrna'
-    
+
   - name: hca_matrix_downloader
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_get-scrna'
-    
+
   - name: sc3_calc_biology
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_sc3_tools'
-    
+
   - name: sc3_calc_consens
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_sc3_tools'
-    
+
   - name: sc3_calc_dists
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_sc3_tools'
-    
+
   - name: sc3_calc_transfs
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_sc3_tools'
-#    
+
   - name: sc3_estimate_k
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_sc3_tools'
-    
+
   - name: sc3_kmeans
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_sc3_tools'
-    
+
   - name: sc3_prepare
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_sc3_tools'
-    
+
   - name: anndata_ops
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-    
+
   - name: scanpy_compute_graph
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-    
+
   - name: scanpy_filter_cells
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-    
+
   - name: scanpy_filter_genes
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-    
+
   - name: scanpy_find_cluster
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-    
+
   - name: scanpy_find_markers
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-    
+
   - name: scanpy_find_variable_genes
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-    
+
   - name: scanpy_normalise_data
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-    
+
   - name: scanpy_parameter_iterator
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-       
+
   - name: scanpy_plot_embed
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-    
+
   - name: scanpy_plot_trajectory
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-    
+
   - name: scanpy_read_10x
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-        
+
   - name: scanpy_regress_variable
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-        
+
   - name: scanpy_run_diffmap
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-        
+
   - name: scanpy_run_dpt
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-        
+
   - name: scanpy_run_fdg
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-        
+
   - name: scanpy_run_paga
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-    
+
   - name: scanpy_run_pca
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-    
+
   - name: scanpy_run_tsne
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-    
+
   - name: scanpy_run_umap
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-    
+
   - name: scanpy_scale_data
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
@@ -139,15 +139,15 @@ tools:
   - name: scanpy_integrate_combat
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-  
+
   - name: scanpy_integrate_harmony
     owner: ebi-gxa
-    tool_panel_section_id: 'hca_sc_scanpy_tools' 
-    
+    tool_panel_section_id: 'hca_sc_scanpy_tools'
+
   - name: scanpy_integrate_mnn
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-    
+
   - name: scanpy_integrate_bbknn
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
@@ -163,119 +163,119 @@ tools:
   - name: scanpy_integrate_bbknn
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scanpy_tools'
-  
+
   - name: seurat_create_seurat_object
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_seurat_tools'
-    
+
   - name: seurat_dim_plot
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_seurat_tools'
-    
+
   - name: seurat_export_cellbrowser
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_seurat_tools'
-    
+
   - name: seurat_filter_cells
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_seurat_tools'
-    
+
   - name: seurat_find_clusters
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_seurat_tools'
-    
+
   - name: seurat_find_markers
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_seurat_tools'
-    
+
   - name: seurat_find_variable_genes
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_seurat_tools'
-    
+
   - name: seurat_normalise_data
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_seurat_tools'
-    
+
   - name: seurat_read10x
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_seurat_tools'
-    
+
   - name: seurat_run_pca
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_seurat_tools'
-    
+
   - name: seurat_run_tsne
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_seurat_tools'
-    
+
   - name: seurat_scale_data
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_seurat_tools'
-    
+
   - name: seurat_find_neighbours
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_seurat_tools'
-    
+
   - name: monocle3_create
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_monocle3_tools'
-  
+
   - name: monocle3_diffexp
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_monocle3_tools'
-    
+
   - name: monocle3_learngraph
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_monocle3_tools'
-    
+
   - name: monocle3_ordercells
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_monocle3_tools'
-    
+
   - name: monocle3_partition
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_monocle3_tools'
-    
+
   - name: monocle3_plotcells
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_monocle3_tools'
-    
+
   - name: monocle3_preprocess
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_monocle3_tools'
-  
+
   - name: monocle3_reducedim
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_monocle3_tools'
-    
+
   - name: monocle3_topmarkers
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_monocle3_tools'
-  
+
   - name: run_sccaf
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_sccaf_tools'
-    
+
   - name: sccaf_asses
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_sccaf_tools'
-    
+
   - name: sccaf_asses_merger
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_sccaf_tools'
-    
+
   - name: sccaf_regress_out
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_sccaf_tools'
-  
+
   - name: scmap_preprocess_sce
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scmap_tools'
-  
+
   - name: scmap_index_cell
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scmap_tools'
-    
+
   - name: scmap_index_cluster
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scmap_tools'
@@ -287,39 +287,39 @@ tools:
   - name: scmap_scmap_cluster
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scmap_tools'
-    
+
   - name: scmap_select_features
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scmap_tools'
-  
+
   - name: scmap_get_std_output
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scmap_tools'
-    
+
   - name: ucsc_cell_browser
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_utils_viz'
-   
+
   - name: sceasy_convert
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_utils_viz'
-    
+
   - name: text_processing
     owner: bgruening
     tool_panel_section_label: 'Text Manipulation'
-    
+
   - name: umi_tools_count
     owner: iuc
     tool_panel_section_label: FASTA/FASTQ
- 
+
   - name: salmon_kallisto_mtx_to_10x
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_utils_viz'
-    
+
   - name: droplet_barcode_plot
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_utils_viz'
-    
+
   - name: ct_build_cell_ontology_dict
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_label_analysis_tools'
@@ -391,7 +391,7 @@ tools:
   - name: scpred_preprocess_data
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scpred_tools'
-    
+
   - name: scpred_predict_labels
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scpred_tools'
@@ -403,23 +403,23 @@ tools:
   - name: scpred_traint_test_split
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scpred_tools'
-    
+
   - name: scater_read_10x_results
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scater_tools'
-    
+
   - name: scater_normalize
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scater_tools'
-    
+
   - name: scater_is_outlier
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scater_tools'
-    
+
   - name: scater_filter
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scater_tools'
-    
+
   - name: scater_calculate_qc_metrics
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scater_tools'
@@ -427,4 +427,3 @@ tools:
   - name: scater_calculate_cpm
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_scater_tools'
-  

--- a/tools_galaxyp.yaml
+++ b/tools_galaxyp.yaml
@@ -51,31 +51,31 @@ tools:
   - name: pyprophet_export
     owner: galaxyp
     tool_panel_section_label: Proteomics
-    
+
   - name: pyprophet_subsample
     owner: galaxyp
     tool_panel_section_label: Proteomics
-    
+
   - name: pyprophet_score
     owner: galaxyp
     tool_panel_section_label: Proteomics
-    
+
   - name: pyprophet_protein
     owner: galaxyp
     tool_panel_section_label: Proteomics
-    
+
   - name: pyprophet_peptide
     owner: galaxyp
     tool_panel_section_label: Proteomics
-    
+
   - name: pyprophet_merge
     owner: galaxyp
     tool_panel_section_label: Proteomics
- 
-  - name:  msstatstmt
+
+  - name: msstatstmt
     owner: galaxyp
     tool_panel_section_label: Proteomics
- 
+
   - name: diffacto
     owner: galaxyp
     tool_panel_section_label: Proteomics
@@ -83,7 +83,7 @@ tools:
   - name: msstats
     owner: galaxyp
     tool_panel_section_label: Proteomics
- 
+
   - name: uniprotxml_downloader
     owner: galaxyp
     tool_panel_section_label: Get Data
@@ -219,7 +219,7 @@ tools:
   - name: cardinal_combine
     owner: galaxyp
     tool_panel_section_label: Proteomics
-    
+
   - name: qupath_roi_splitter
     owner: galaxyp
     tool_panel_section_label: Proteomics
@@ -235,7 +235,7 @@ tools:
   - name: eggnog_mapper
     owner: galaxyp
     tool_panel_section_label: Proteomics
- 
+
   - name: protein_properties
     owner: bgruening
     tool_panel_section_label: Proteomics
@@ -254,7 +254,7 @@ tools:
 
   - name: idpquery
     owner: galaxyp
-    tool_panel_section_label: Proteomics
+    tool_panel_section_label: Convert Formats
 
   - name: proteomics_moff
     owner: galaxyp
@@ -282,32 +282,32 @@ tools:
 
   - name: pep_pointer
     owner: galaxyp
-    tool_panel_section_label: Proteomics  
-    
+    tool_panel_section_label: Proteomics
+
   - name: metaquantome_db
     owner: galaxyp
-    tool_panel_section_label: Proteomics  
-    
+    tool_panel_section_label: Proteomics
+
   - name: metaquantome_expand
     owner: galaxyp
-    tool_panel_section_label: Proteomics  
-    
+    tool_panel_section_label: Proteomics
+
   - name: metaquantome_filter
     owner: galaxyp
-    tool_panel_section_label: Proteomics  
-    
+    tool_panel_section_label: Proteomics
+
   - name: metaquantome_sample
     owner: galaxyp
-    tool_panel_section_label: Proteomics  
-    
+    tool_panel_section_label: Proteomics
+
   - name: metaquantome_stat
     owner: galaxyp
-    tool_panel_section_label: Proteomics  
-    
+    tool_panel_section_label: Proteomics
+
   - name: metaquantome_viz
     owner: galaxyp
-    tool_panel_section_label: Proteomics 
-    
+    tool_panel_section_label: Proteomics
+
   - name: maxbin2
     owner: mbernt
     tool_panel_section_label: Metagenomic Analysis
@@ -315,31 +315,31 @@ tools:
   - name: msms_extractor
     owner: galaxyp
     tool_panel_section_label: Convert Formats
-    
+
   - name: peptide_genomic_coordinate
     owner: galaxyp
     tool_panel_section_label: Proteomics
-    
+
   - name: quantwiz_iq
     owner: galaxyp
     tool_panel_section_label: Proteomics
-    
+
   - name: sixgill
     owner: galaxyp
     tool_panel_section_label: Metagenomic Analysis
-    
+
   - name: metagene_annotator
     owner: galaxyp
     tool_panel_section_label: Metagenomic Analysis
-    
+
   - name: pepquery
     owner: galaxyp
     tool_panel_section_label: Proteomics
-     
+
   - name: mt2mq
     owner: galaxyp
     tool_panel_section_label: Proteomics
-    
+
   - name: openms_rnadigestor
     owner: galaxyp
     tool_panel_section_label: Proteomics
@@ -983,16 +983,16 @@ tools:
   - name: openms_databasefilter
     owner: galaxyp
     tool_panel_section_label: Proteomics
-    
-    
+
+
   - name: psm_validation
     owner: galaxyp
     tool_panel_section_label: Proteomics
-    
+
   - name: meta_proteome_analyzer
     owner: galaxyp
     tool_panel_section_label: Proteomics
-    
+
   - name: fastg2protlib
     owner: galaxyp
     tool_panel_section_label: Proteomics

--- a/tools_galaxyp.yaml.lock
+++ b/tools_galaxyp.yaml.lock
@@ -602,7 +602,7 @@ tools:
   - 51d54a9c9283
   - 66c38e74d1ae
   - 6da05a8b5d8b
-  tool_panel_section_label: Proteomics
+  tool_panel_section_label: Convert Formats
 - name: proteomics_moff
   owner: galaxyp
   revisions:

--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -186,7 +186,7 @@ tools:
   - name: homer_annotatepeaks
     owner: iuc
     tool_panel_section_label: Annotation
-    
+
   - name: homer_findmotifs
     owner: iuc
     tool_panel_section_label: Annotation
@@ -657,7 +657,7 @@ tools:
 
   - name: bwameth
     owner: iuc
-    tool_panel_section_label: Epigenetics
+    tool_panel_section_label: Mapping
 
   - name: moabs
     owner: iuc
@@ -758,7 +758,7 @@ tools:
   - name: bbtools_bbduk
     owner: iuc
     tool_panel_section_label: FASTA/FASTQ
-    
+
   - name: bbtools_bbmerge
     owner: iuc
     tool_panel_section_label: FASTA/FASTQ
@@ -993,23 +993,23 @@ tools:
 
   - name: umi_tools_dedup
     owner: iuc
-    tool_panel_section_label:  FASTA/FASTQ
+    tool_panel_section_label: FASTA/FASTQ
 
   - name: umi_tools_extract
     owner: iuc
-    tool_panel_section_label:  FASTA/FASTQ
+    tool_panel_section_label: FASTA/FASTQ
 
   - name: umi_tools_group
     owner: iuc
-    tool_panel_section_label:  FASTA/FASTQ
+    tool_panel_section_label: FASTA/FASTQ
 
   - name: umi_tools_whitelist
     owner: iuc
-    tool_panel_section_label:  FASTA/FASTQ
+    tool_panel_section_label: FASTA/FASTQ
 
   - name: fasta_regex_finder
     owner: mbernt
-    tool_panel_section_label:  FASTA/FASTQ
+    tool_panel_section_label: FASTA/FASTQ
 
 
 # FILTER AND SORT
@@ -1516,7 +1516,7 @@ tools:
 
   - name: subtract
     owner: devteam
-    tool_panel_section_label: Join, Subtract and Group
+    tool_panel_section_label: Operate on Genomic Intervals
 
 
 # MACHINE LEARNING
@@ -1878,10 +1878,10 @@ tools:
   - name: data_manager_build_bracken_database
     owner: iuc
 
-  - name: amrfinderplus_data_manager_build 
+  - name: amrfinderplus_data_manager_build
     owner: iuc
 
-  - name: data_manager_bakta 
+  - name: data_manager_bakta
     owner: iuc
 
   - name: drep_compare
@@ -2894,7 +2894,7 @@ tools:
 
   - name: bbtools_bbduk
     owner: iuc
-    tool_panel_section_label: NCBI Blast
+    tool_panel_section_label: FASTA/FASTQ
 
   - name: diamond
     owner: bgruening
@@ -3465,7 +3465,7 @@ tools:
   - name: migmap
     owner: iuc
     tool_panel_section_label: RNA Analysis
-  
+
   - name: mirnature
     owner: iuc
     tool_panel_section_label: RNA Analysis
@@ -3488,7 +3488,7 @@ tools:
 
   - name: rnaquast
     owner: iuc
-    tool_panel_section_label: RNA Analysis
+    tool_panel_section_label: Assembly
 
   - name: rseqc
     owner: nilesh
@@ -3611,7 +3611,7 @@ tools:
 
   - name: draw_stacked_barplots
     owner: devteam
-    tool_panel_section_label: Regional Variation
+    tool_panel_section_label: Graph/Display Data
 
   - name: featurecounter
     owner: devteam
@@ -3986,7 +3986,7 @@ tools:
     owner: iuc
     tool_panel_section_label: Statistics
 
-  ## IWtomic - Interval-Wise Testing for Omics Data
+    ## IWtomic - Interval-Wise Testing for Omics Data
 
   - name: iwtomics_loadandplot
     owner: iuc
@@ -4041,11 +4041,11 @@ tools:
 
   - name: basecoverage
     owner: devteam
-    tool_panel_section_label: Text Manipulation
+    tool_panel_section_label: Operate on Genomic Intervals
 
   - name: cluster
     owner: devteam
-    tool_panel_section_label: Text Manipulation
+    tool_panel_section_label: Operate on Genomic Intervals
 
   - name: column_maker
     owner: devteam
@@ -4109,7 +4109,7 @@ tools:
 
   - name: prinseq
     owner: iuc
-    tool_panel_section_label: Text Manipulation
+    tool_panel_section_label: FASTA/FASTQ
 
   - name: query_tabular
     owner: iuc
@@ -4125,7 +4125,7 @@ tools:
 
   - name: subtract
     owner: devteam
-    tool_panel_section_label: Text Manipulation
+    tool_panel_section_label: Operate on Genomic Intervals
 
   - name: subtract_query
     owner: devteam
@@ -4788,7 +4788,7 @@ tools:
   - name: data_manager_semibin
     owner: iuc
 
-  - name: data_manager_vep_cache_downloader 
+  - name: data_manager_vep_cache_downloader
     owner: iuc
 
   - name: data_manager_pharokka

--- a/tools_iuc.yaml.lock
+++ b/tools_iuc.yaml.lock
@@ -1343,7 +1343,7 @@ tools:
   - b4e6819b25ef
   - d82648ad25a3
   - f7094efef903
-  tool_panel_section_label: Epigenetics
+  tool_panel_section_label: Mapping
 - name: moabs
   owner: iuc
   revisions:
@@ -3259,7 +3259,7 @@ tools:
   - 0427ca314f3d
   - 5bc2dacbe729
   - 7a2a604ae9c8
-  tool_panel_section_label: Join, Subtract and Group
+  tool_panel_section_label: Operate on Genomic Intervals
 - name: deepmicro
   owner: iuc
   revisions:
@@ -6291,7 +6291,7 @@ tools:
   - 204a131e47db
   - 425dab0e057b
   - a9c9d768b751
-  tool_panel_section_label: NCBI Blast
+  tool_panel_section_label: FASTA/FASTQ
 - name: diamond
   owner: bgruening
   revisions:
@@ -6931,7 +6931,7 @@ tools:
   owner: iuc
   revisions:
   - 02f0dfb10421
-  - 0407236012e5
+  - 4072360120e4
   - 1d9d3c6bc246
   - 6d29207a32c5
   - 6fede7bd6c8f
@@ -7888,7 +7888,7 @@ tools:
   - 96f74538896e
   - e989670c7fc7
   - f89e3c318453
-  tool_panel_section_label: RNA Analysis
+  tool_panel_section_label: Assembly
 - name: rseqc
   owner: nilesh
   revisions:
@@ -8199,7 +8199,7 @@ tools:
   owner: devteam
   revisions:
   - e997b710e38a
-  tool_panel_section_label: Regional Variation
+  tool_panel_section_label: Graph/Display Data
 - name: featurecounter
   owner: devteam
   revisions:
@@ -9061,7 +9061,7 @@ tools:
   - 1e6a9e97fa41
   - 2cedec3759e4
   - 9c5ff4695c97
-  tool_panel_section_label: Text Manipulation
+  tool_panel_section_label: Operate on Genomic Intervals
 - name: cluster
   owner: devteam
   revisions:
@@ -9069,7 +9069,7 @@ tools:
   - 765ceb06c3e2
   - a126ec6ea0e4
   - d5677eecbad4
-  tool_panel_section_label: Text Manipulation
+  tool_panel_section_label: Operate on Genomic Intervals
 - name: column_maker
   owner: devteam
   revisions:
@@ -9182,7 +9182,7 @@ tools:
   - 1ee282794de3
   - 654b3a274ed5
   - 6b865dde1baa
-  tool_panel_section_label: Text Manipulation
+  tool_panel_section_label: FASTA/FASTQ
 - name: query_tabular
   owner: iuc
   revisions:
@@ -9206,7 +9206,7 @@ tools:
   - 0427ca314f3d
   - 5bc2dacbe729
   - 7a2a604ae9c8
-  tool_panel_section_label: Text Manipulation
+  tool_panel_section_label: Operate on Genomic Intervals
 - name: subtract_query
   owner: devteam
   revisions:


### PR DESCRIPTION
I used:
```python
#!/usr/bin/env python
import glob
import json
import os
import sys
import ruamel.yaml

disambig = {}
if len(sys.argv) > 1:
    pref_json_fn = sys.argv[1]
    with open(pref_json_fn, 'r') as f:
        disambig = json.load(f)


yaml = ruamel.yaml.YAML()
yaml.preserve_quotes = True

for fn in sorted(glob.glob("*.yaml")):
    with open(fn, 'r') as handle:
        tools = yaml.load(handle)
        for x in tools['tools']:
            name=f"{x['owner']}/{x['name']}"
            if 'tool_panel_section_label' in x:
                if name in disambig:
                    x['tool_panel_section_label'] = disambig[name]
    
    with open(fn, 'w') as fo:
        yaml.dump(tools, fo)
```
and:
```json
{
    "bebatut/format_cd_hit_output": "Multiple Alignments",
    "bgruening/interproscan5": "Annotation",
    "bgruening/pileometh": "Peak Calling",
    "crs4/taxonomy_krona_chart": "Metagenomic Analysis",
    "devteam/basecoverage": "Operate on Genomic Intervals",
    "devteam/cluster": "Operate on Genomic Intervals",
    "devteam/complement": "Operate on Genomic Intervals",
    "devteam/draw_stacked_barplots": "Graph/Display Data",
    "devteam/kraken": "Metagenomic Analysis",
    "devteam/kraken_filter": "Metagenomic Analysis",
    "devteam/kraken_report": "Metagenomic Analysis",
    "devteam/kraken_translate": "Metagenomic Analysis",
    "devteam/kraken2tax": "Metagenomic Analysis",
    "devteam/subtract": "Operate on Genomic Intervals",
    "ecology/cb_dissim": "Compute indicators for turnover boulders fields",
    "ecology/cb_ivr": "Compute indicators for turnover boulders fields",
    "ethevenot/biosigner": "Statistics",
    "ethevenot/heatmap": "Statistics",
    "ethevenot/multivariate": "Statistics",
    "ethevenot/transformation": "Statistics",
    "ethevenot/univariate": "Statistics",
    "galaxyp/idpquery": "Convert Formats",
    "galaxyp/msconvert": "Convert Formats",
    "galaxyp/msms_extractor": "Convert Formats",
    "galaxyp/thermo_raw_file_converter": "Convert Formats",
    "goeckslab/mesmer": "Spatial Omics",
    "hammock/hammock": "Multiple Alignments",
    "iuc/bbtools_bbduk": "FASTA/FASTQ",
    "iuc/bwameth": "Mapping",
    "iuc/kraken_taxonomy_report": "Metagenomic Analysis",
    "iuc/prinseq": "FASTA/FASTQ",
    "iuc/rnaquast": "Assembly",
    "lecorguille/anova": "Statistics",
    "peterjc/sample_seqs": "NCBI Blast",
    "prog/lcmsmatching": "Annotation",
    "sauria/hifive": "Epigenetics"
}
```

So in addition to the section_label changes there are a lot of 'linting'.
(However, I manually put back the indentation of tools)