### PR TITLE
Add bbtools_tadpole, SeqSero2, and RGI

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -4812,9 +4812,6 @@ tools:
   - name: data_manager_mapseq
     owner: iuc
 
-  - name: rgi_database_builder
-    owner: card
-
 # DEEPTOOLS
 
   - name: deeptools_alignmentsieve

--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -4812,6 +4812,9 @@ tools:
   - name: data_manager_mapseq
     owner: iuc
 
+  - name: rgi_database_builder
+    owner: card
+
 # DEEPTOOLS
 
   - name: deeptools_alignmentsieve

--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -287,6 +287,10 @@ tools:
     owner: csbl
     tool_panel_section_label: Annotation
 
+  - name: rgi
+    owner: card
+    tool_panel_section_label: Annotation
+
   - name: roary
     owner: iuc
     tool_panel_section_label: Annotation
@@ -763,6 +767,10 @@ tools:
     tool_panel_section_label: FASTA/FASTQ
 
   - name: bbtools_bbmerge
+    owner: iuc
+    tool_panel_section_label: FASTA/FASTQ
+
+  - name: bbtools_tadpole
     owner: iuc
     tool_panel_section_label: FASTA/FASTQ
 
@@ -2256,6 +2264,10 @@ tools:
     tool_panel_section_label: Metagenomic Analysis
 
   - name: semibin_train
+    owner: iuc
+    tool_panel_section_label: Metagenomic Analysis
+
+  - name: seqsero2
     owner: iuc
     tool_panel_section_label: Metagenomic Analysis
 

--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -287,10 +287,6 @@ tools:
     owner: csbl
     tool_panel_section_label: Annotation
 
-  - name: rgi
-    owner: card
-    tool_panel_section_label: Annotation
-
   - name: roary
     owner: iuc
     tool_panel_section_label: Annotation


### PR DESCRIPTION
The RGI wrapper and data manager is provided by card, which is also de developer of RGI. I wasn't sure if this was allowed so let me know if it belongs somewhere else.

I didn't run into any problems running it on our own instance.

https://github.com/arpcard/rgi_wrapper/tree/master
