### PR TITLE
Add `voronoi_tessellation` tool

### DIFF
--- a/imaging.yaml
+++ b/imaging.yaml
@@ -312,6 +312,10 @@ tools:
     owner: imgteam
     tool_panel_section_label: "Imaging"
 
+  - name: voronoi_tessellation
+    owner: imgteam
+    tool_panel_section_label: "Imaging"
+
   - name: cp_cellprofiler
     owner: bgruening
     tool_panel_section_label: "Imaging"

--- a/imaging.yaml.lock
+++ b/imaging.yaml.lock
@@ -561,6 +561,8 @@ tools:
   revisions:
   - 33b2ca53a566
   tool_panel_section_label: Imaging
+- name: voronoi_tessellation
+  owner: imgteam
 - name: cp_cellprofiler
   owner: bgruening
   revisions:


### PR DESCRIPTION
Add the `voronoi_tessellation` tool from https://github.com/BMCV/galaxy-image-analysis/pull/108

Hopefully I understood [your comment](https://github.com/usegalaxy-eu/usegalaxy-eu-tools/pull/686#pullrequestreview-1926323820) @bgruening correctly that I still need to add the entries for new tools to the .lock files, but not their revisions.