### PR TITLE
add tracegroomer

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -5047,3 +5047,9 @@ tools:
   - name: dimet_bivariate_analysis
     owner: iuc
     tool_panel_section_label: Metabolomics
+
+# METABOLOMICS TRACEGROOMER
+
+  - name: tracegroomer
+    owner: iuc
+    tool_panel_section_label: Metabolomics


### PR DESCRIPTION
TraceGroomer is a solution for formatting and normalising Tracer metabolomics given file(s), to produce the .csv files which are ready for DIMet tool.