### PR TITLE
Add qiime visualisation viewer tool

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -2485,6 +2485,10 @@ tools:
   - name: vsearch
     owner: iuc
     tool_panel_section_label: Metagenomic Analysis
+    
+  - name: qiime_extract_viz
+    owner: iuc
+    tool_panel_section_label: Metagenomic Analysis
 
 
 # MOTHUR


### PR DESCRIPTION
Allows for the viewing of QIIME2 visualisation artifacts (qzv outputs) inside Galaxy.



