### PR TITLE
Add falco - FastQC Alternative Code

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -1168,6 +1168,10 @@ tools:
   - name: rasusa
     owner: iuc
     tool_panel_section_label: FASTA/FASTQ
+  
+  - name: falco
+    owner: iuc
+    tool_panel_section_label: FASTA/FASTQ
 
 
 # FILTER AND SORT


### PR DESCRIPTION
Allows for the viewing of Falco (FastQC Alternative Code) tool inside Galaxy.