### PR TITLE
Add refseq_masher to assembly analysis

### DIFF
--- a/asaim.yaml
+++ b/asaim.yaml
@@ -90,6 +90,10 @@ tools:
     owner: 'iuc'
     tool_panel_section_label: 'Assembly'
 
+  - name: 'refseq_masher'
+    owner: 'nml'
+    tool_panel_section_label: 'Assembly'   
+
   - name: 'valet'
     owner: 'iuc'
     tool_panel_section_label: 'Metagenomic Analysis'


### PR DESCRIPTION
It will be used for the 'Bacterial genome assembly' workflow as mentioned is this [PR](https://github.com/galaxyproject/iwc/pull/438)

Thanks !