### PR TITLE
Removing EAR until the issue is resolved

### DIFF
--- a/bgruening.yaml
+++ b/bgruening.yaml
@@ -113,9 +113,6 @@ tools:
     owner: bgruening
     tool_panel_section_label: Assembly
   
-  - name: make_ear
-    owner: bgruening
-    tool_panel_section_label: Assembly
 
 # COLLECTION OPERATIONS
 


### PR DESCRIPTION
There seems to be some issue with the [ERGA EAR tool](https://github.com/bgruening/galaxytools/pull/1436) 

This is causing the CI of the **usegalaxy-eu-tools** to fail. Removing this tool for time being. 

Once the error is fixed, will link tool again.

Sorry for inconvenience!