### PR TITLE
add beacon-import tools

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -4554,6 +4554,54 @@ tools:
     owner: iuc
     tool_panel_section_label: Variant Calling
 
+  - name: beacon2_analyses
+    owner: iuc
+    tool_panel_section_label: Variant Calling
+
+  - name: beacon2_biosamples
+    owner: iuc
+    tool_panel_section_label: Variant Calling
+
+  - name: beacon2_bracket
+    owner: iuc
+    tool_panel_section_label: Variant Calling
+
+  - name: beacon2_cnv
+    owner: iuc
+    tool_panel_section_label: Variant Calling
+
+  - name: beacon2_cohorts
+    owner: iuc
+    tool_panel_section_label: Variant Calling
+
+  - name: beacon2_datasets
+    owner: iuc
+    tool_panel_section_label: Variant Calling
+
+  - name: beacon2_gene
+    owner: iuc
+    tool_panel_section_label: Variant Calling
+
+  - name: beacon2_import
+    owner: iuc
+    tool_panel_section_label: Variant Calling
+
+  - name: beacon2_individuals
+    owner: iuc
+    tool_panel_section_label: Variant Calling
+
+  - name: beacon2_range
+    owner: iuc
+    tool_panel_section_label: Variant Calling
+
+  - name: beacon2_runs
+    owner: iuc
+    tool_panel_section_label: Variant Calling
+
+  - name: beacon2_sequence
+    owner: iuc
+    tool_panel_section_label: Variant Calling
+
   - name: beagle
     owner: iuc
     tool_panel_section_label: Variant Calling


### PR DESCRIPTION
Before merging please update the use. Galaxy user_preferences_extra_conf.yml with the following. 

```
preferences:
    beacon2_account:
        description: Your own Beacon2 account
        inputs:
            - name: db_auth_source
              label: Beacon Database Authentication Source
              type: text
              required: False
            - name: db_user
              label: Beacon Database Username
              type: text
              required: False
            - name: db_password
              label: Beacon Database Password
              type: password
              store: vault
              required: False
```


The tool uses credentials and they should be stored in a vault 

```
#set $db_auth_source = $__user__.extra_preferences.get('beacon2_account|db_auth_source', "")
            #set $db_user = $__user__.extra_preferences.get('beacon2_account|db_user', "")
            #set $db_password = $__user__.extra_preferences.get('beacon2_account|db_password', "")
            #if $db_user == "" or $db_password == "" or $db_auth_source == "":
                #set $db_auth_source = "admin"
                #set $db_user = "root"
                #set $db_password = "example"
            #end if
            {
                "db_auth_source": "$db_auth_source",
                "db_user": "$db_user",
                "db_password": "$db_password"
            }
```