### PR TITLE
fix bogus revision for bigwig_outlier_bed

### DIFF
--- a/tools_iuc.yaml.lock
+++ b/tools_iuc.yaml.lock
@@ -2442,6 +2442,7 @@ tools:
 - name: bigwig_outlier_bed
   owner: iuc
   revisions:
+  - 61946b8bd43b
   - ebcd48f183b3
   tool_panel_section_label: Filter and Sort
 - name: gemini_actionable_mutations


### PR DESCRIPTION
not currently on eu because  the revision was wrong.