### PR TITLE
Added spec2vec suite and utility to merge annotations

### DIFF
--- a/eirene.yaml
+++ b/eirene.yaml
@@ -155,6 +155,10 @@ tools:
     owner: recetox
     tool_panel_section_label: Metabolomics
 
+  - name: rename_annotated_feature
+    owner: recetox
+    tool_panel_section_label: Metabolomics
+
   - name: assign_ri_from_comment
     owner: recetox
     tool_panel_section_label: Metabolomics
@@ -173,4 +177,12 @@ tools:
 
   - name: xcms_plot_eic
     owner: workflow4metabolomics
+    tool_panel_section_label: Metabolomics
+
+  - name: spec2vec_similarity
+    owner: recetox
+    tool_panel_section_label: Metabolomics
+
+  - name: spec2vec_training
+    owner: recetox
     tool_panel_section_label: Metabolomics


### PR DESCRIPTION
This adds the spec2vec training and similarity tools which are based on matchms.
Also adds the "rename annotated features" utility which takes an annotation and intensity table and renames the columns in the intensity table based on the annotations.