### PR TITLE
Add multiple tools [Taxonkit name2taxid, gtdb_to_taxdump and biobox_add_taxid]

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -1820,6 +1820,10 @@ tools:
     owner: iuc
     tool_panel_section_label: Metagenomic Analysis
 
+  - name: name2taxid
+    owner: iuc
+    tool_panel_section_label: Metagenomic Analysis
+
   - name: krakentools_kreport2krona
     owner: iuc
     tool_panel_section_label: Metagenomic Analysis

--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -1824,6 +1824,10 @@ tools:
     owner: iuc
     tool_panel_section_label: Metagenomic Analysis
 
+  - name: ncbi_gtdb_map
+    owner: iuc
+    tool_panel_section_label: Metagenomic Analysis
+
   - name: krakentools_kreport2krona
     owner: iuc
     tool_panel_section_label: Metagenomic Analysis

--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -1824,7 +1824,7 @@ tools:
     owner: iuc
     tool_panel_section_label: Metagenomic Analysis
 
-  - name: ncbi_gtdb_map
+  - name: gtdb_to_taxdump
     owner: iuc
     tool_panel_section_label: Metagenomic Analysis
 

--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -1828,6 +1828,10 @@ tools:
     owner: iuc
     tool_panel_section_label: Metagenomic Analysis
 
+  - name: biobox_add_taxid
+    owner: iuc
+    tool_panel_section_label: Metagenomic Analysis
+
   - name: krakentools_kreport2krona
     owner: iuc
     tool_panel_section_label: Metagenomic Analysis


### PR DESCRIPTION
Tools for CAMI Amber such that it can be fully used now. 