### PR TITLE
added new mfassignr tool and ms2deepscore

### DIFF
--- a/eirene.yaml
+++ b/eirene.yaml
@@ -218,7 +218,23 @@ tools:
   - name: mfassignr_recallist
     owner: recetox
     tool_panel_section_label: Metabolomics
+  
+  - name: mfassignr_findrecalseries
+    owner: recetox
+    tool_panel_section_label: Metabolomics
 
   - name: rcx_tk
+    owner: recetox
+    tool_panel_section_label: Metabolomics
+
+  - name: ms2deepscore_config_generator
+    owner: recetox
+    tool_panel_section_label: Metabolomics
+
+  - name: ms2deepscore_similarity
+    owner: recetox
+    tool_panel_section_label: Metabolomics
+
+  - name: ms2deepscore_training
     owner: recetox
     tool_panel_section_label: Metabolomics


### PR DESCRIPTION
This PR adds the newly added tool from the MFAssignR suite which automatically finds the best calibration series and the new ms2deepscore tool suite which includes tools for training config generation, model training and inference.

It would be great if the tools could be installed before the regular update cycle so we can work on the trainings and things we want to make for those tools already this week, to have the whole workflow on usegalaxy.eu etc. :)