### PR TITLE
Add squirrel_phylo and squirrel_qc

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -3599,6 +3599,14 @@ tools:
     owner: iuc
     tool_panel_section_label: Phylogenetics
 
+  - name: squirrel_phylo
+    owner: iuc
+    tool_panel_section_label: Phylogenetics
+
+  - name: squirrel_qc
+    owner: iuc
+    tool_panel_section_label: Phylogenetics
+
 
 # PICARD
 


### PR DESCRIPTION
The two tools are wrappers for the [Squirrel](https://github.com/aineniamh/squirrel) tool that is used in Mpox virus (MPXV) analysis. I have added them to the Phylogenetics section because other, similar, tools for viral analysis (such as Nextclade and Pangolin) are in there.
