### PR TITLE
Add tools from the new EMBOSS v6 suite

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -396,7 +396,7 @@ tools:
   - name: spotyping
     owner: iuc
     tool_panel_section_label: Annotation
-  
+
   - name: staramr
     owner: iuc
     tool_panel_section_label: Annotation
@@ -844,6 +844,16 @@ tools:
 
   - name: emboss_5
     owner: devteam
+    tool_panel_section_label: EMBOSS
+
+# EMBOSS 6 tool suite
+
+  - name: emboss_needleall
+    owner: iuc
+    tool_panel_section_label: EMBOSS
+
+  - name: emboss_needle
+    owner: iuc
     tool_panel_section_label: EMBOSS
 
 


### PR DESCRIPTION
@bgruening I added both needleall and needle, but needle also has a v5 wrapper installed on EU currently, so not sure how to handle that to minimize confusion, do we deprecate the old version, make a different EMBOSS6 toolbox section?