### PR TITLE
Remove tools that are no longer installed on EU

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ install: $(INSTALL_YAMLS) ## Install the tools in our galaxy
 %.fix: %
 	@# Generates the lockfile or updates it if it is missing tools
 	python3 scripts/fix-lockfile.py $<
+
+	@# remove revisions that have been uninstalled on EU
+	python3 scripts/fix_not_installed.py --galaxy_url https://usegalaxy.eu $<
+
 	@# --without says only add those hashes for those missing hashes (i.e. new tools)
 	python3 scripts/update-tool.py $< --without
 

--- a/scripts/fix_not_installed.py
+++ b/scripts/fix_not_installed.py
@@ -1,9 +1,12 @@
 # check all revisions in the lockfile if they are still installed
 # at a given Galaxy instance and remove them from the lock file if not
+# 
+# if a tool is not installed anymore or ha nos installed revisions
+# it is kept with an empty list of revisions
 #
 # The tool logs INFO messages for each removed revision
 # and prints WARNING messages for tools that are not installed
-# anymore
+# anymore or that have no mopre installed revisions
 
 import argparse
 import logging
@@ -41,6 +44,7 @@ def fix_not_installed(lockfile_name: str, galaxy_url: str) -> None:
         owner = locked_tool["owner"]
         if (name, owner) not in installed_tools:
             logger.warning(f"{name},{owner} not installed anymore")
+            locked_tool["revisions"] = []
             continue
 
         to_remove = []
@@ -51,6 +55,9 @@ def fix_not_installed(lockfile_name: str, galaxy_url: str) -> None:
 
         for r in to_remove:
             locked_tool["revisions"].remove(r)
+
+        if len(locked_tool["revisions"]) == 0:
+            logger.warning(f"{name},{owner} has no more installed revisions")
         locked_tool["revisions"] = sorted(list(set(map(str, locked_tool["revisions"]))))
 
     with open(lockfile_name, "w") as handle:

--- a/scripts/fix_not_installed.py
+++ b/scripts/fix_not_installed.py
@@ -1,0 +1,84 @@
+# check all revisions in the lockfile if they are still installed
+# at a given Galaxy instance and remove them from the lock file if not
+#
+# The tool logs INFO messages for each removed revision
+# and prints WARNING messages for tools that are not installed
+# anymore
+
+import argparse
+import logging
+import yaml
+from typing import (
+    Dict,
+    Set,
+    Tuple,
+)
+
+from bioblend import galaxy
+
+
+logger = logging.getLogger()
+
+
+def fix_not_installed(lockfile_name: str, galaxy_url: str) -> None:
+
+    gi = galaxy.GalaxyInstance(url=galaxy_url, key=None)
+    installed_tools: Dict[Tuple[str, str], Set[str]] = {}
+    for t in gi.toolshed.get_repositories():
+        if (t["name"], t["owner"]) not in installed_tools:
+            installed_tools[(t["name"], t["owner"])] = set()
+        # TODO? could also check for 'status': 'Installed'
+        if t["deleted"] or t["uninstalled"]:
+            continue
+        installed_tools[(t["name"], t["owner"])].add(t["changeset_revision"])
+
+    with open(lockfile_name) as f:
+        lockfile = yaml.safe_load(f)
+        locked_tools = lockfile["tools"]
+
+    for i, locked_tool in enumerate(locked_tools):
+        name = locked_tool["name"]
+        owner = locked_tool["owner"]
+        if (name, owner) not in installed_tools:
+            logger.warning(f"{name},{owner} not installed anymore")
+            continue
+
+        to_remove = []
+        for cur in locked_tool["revisions"]:
+            if cur not in installed_tools[(name, owner)]:
+                logger.info(f"{name},{owner} remove {cur} ")
+                to_remove.append(cur)
+
+        for r in to_remove:
+            locked_tool["revisions"].remove(r)
+        locked_tool["revisions"] = sorted(list(set(map(str, locked_tool["revisions"]))))
+
+    with open(lockfile_name, "w") as handle:
+        yaml.dump(lockfile, handle, default_flow_style=False)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "lockfile", type=argparse.FileType("r"), help="Tool.yaml.lock file"
+    )
+    parser.add_argument(
+        "--galaxy_url",
+        help="Galaxy instance to check. If given it is checked if the not-installable revision is still installed.",
+    )
+    args = parser.parse_args()
+
+    logger.setLevel(logging.DEBUG)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+    logging.getLogger("bioblend").setLevel(logging.WARNING)
+    logging.getLogger("PIL.Image").setLevel(logging.WARNING)
+    # otherwise tool loading errors (of there are other xml files that can't be parsed?) are still reported
+    logging.getLogger("galaxy.util").disabled = True
+    handler = logging.StreamHandler()
+    logger.addHandler(handler)
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+    handler.setFormatter(formatter)
+
+    fix_not_installed(args.lockfile.name, args.galaxy_url)


### PR DESCRIPTION
Simple preprocessing step for https://github.com/usegalaxy-eu/usegalaxy-eu-tools/pull/838

Will remove 4266 revisions (keeping 12031). See: https://github.com/usegalaxy-eu/usegalaxy-eu-tools/pull/844

There are a few tools which will have no revisions left after the run of the script. I guess these are covered by in other yaml files in most cases. Odd is `data_manager_diamond_database_builder`.

```
asaim.yaml.lock.log:2025-04-09 18:22:12,321 - root - WARNING - data_manager_sortmerna_database_downloader,rnateam has no more installed revisions
asaim.yaml.lock.log:2025-04-09 18:22:12,321 - root - WARNING - bwa,devteam has no more installed revisions
asaim.yaml.lock.log:2025-04-09 18:22:12,321 - root - WARNING - metaspades,nml has no more installed revisions
asaim.yaml.lock.log:2025-04-09 18:22:12,321 - root - WARNING - interproscan5,bgruening has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,123 - root - WARNING - paralyzer,rnateam has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,123 - root - WARNING - transformation,ethevenot has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,123 - root - WARNING - heatmap,ethevenot has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,123 - root - WARNING - taxonomy_krona_chart,crs4 has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,123 - root - WARNING - split_file_on_column,bgruening has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,123 - root - WARNING - tables_arithmetic_operations,devteam has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,123 - root - WARNING - uniprot_rest_interface,bgruening has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,124 - root - WARNING - lighter,bgruening has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,124 - root - WARNING - je_markdupes,gbcs-embl-heidelberg has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,124 - root - WARNING - fasta_filter_by_length,devteam has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,124 - root - WARNING - cuffdiff,devteam has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,124 - root - WARNING - cuffquant,devteam has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,124 - root - WARNING - cuffnorm,devteam has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,124 - root - WARNING - macs,devteam has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,124 - root - WARNING - hardklor,galaxyp has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,124 - root - WARNING - autodock_vina_prepare_ligand,bgruening has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,124 - root - WARNING - autodock_vina,bgruening has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,124 - root - WARNING - emboss_5,devteam has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,124 - root - WARNING - taxonomy_krona_chart,crs4 has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,125 - root - WARNING - bamtools_filter,devteam has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,125 - root - WARNING - samtools_rmdup,devteam has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,125 - root - WARNING - samtool_filter2,devteam has no more installed revisions
europe-custom.yaml.lock.log:2025-04-09 18:24:18,125 - root - WARNING - samtools_phase,devteam has no more installed revisions
graphclust.yaml.lock.log:2025-04-09 18:25:01,344 - root - WARNING - graphclust_postprocessing,rnateam has no more installed revisions
tools_iuc.yaml.lock.log:2025-04-09 18:27:29,659 - root - WARNING - data_manager_diamond_database_builder,iuc not installed anymore
tools_q2d2.yaml.lock.log:2025-04-09 18:27:40,226 - root - WARNING - qiime2__deblur__denoise_16S,q2d2 not installed anymore
```