### PR TITLE
add icescreen tool from IUC repo

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -282,6 +282,10 @@ tools:
     owner: iuc
     tool_panel_section_label: Annotation
 
+  - name: icescreen
+    owner: iuc
+    tool_panel_section_label: Annotation
+
   - name: integron_finder
     owner: iuc
     tool_panel_section_label: Annotation


### PR DESCRIPTION
Hi,
I would like to add the icescreen tool to usegalaxy eu. The tool is available on the toolshed via the IUC repo.
Best,
Thomas