### PR TITLE
Add FBQS Integrator tool to diverse.yaml

### DIFF
--- a/diverse.yaml
+++ b/diverse.yaml
@@ -46,4 +46,4 @@ tools:
 
   - name: fbqs_integrator
     owner: SPAMR-VET
-    tool_panel_section_label: Quality Control
+    tool_panel_section_label: Assembly

--- a/diverse.yaml
+++ b/diverse.yaml
@@ -44,3 +44,6 @@ tools:
     owner: recetox
     tool_panel_section_label: Metabolomics   
 
+  - name: fbqs_integrator
+    owner: SPAMR-VET
+    tool_panel_section_label: Quality Control

--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -1,13 +1,3 @@
----
-install_repository_dependencies: true
-install_resolver_dependencies: true
-install_tool_dependencies: false
-
-tools:
- - name: fbqs_integrator
-    owner: SPAMR-VET
-    tool_panel_section_label: Quality Control
-    
 # ANNOTATION
 
   - name: abricate

--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -4,7 +4,10 @@ install_resolver_dependencies: true
 install_tool_dependencies: false
 
 tools:
-
+ - name: fbqs_integrator
+    owner: SPAMR-VET
+    tool_panel_section_label: Quality Control
+    
 # ANNOTATION
 
   - name: abricate

--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -1,5 +1,10 @@
-# ANNOTATION
+---
+install_repository_dependencies: true
+install_resolver_dependencies: true
+install_tool_dependencies: false
 
+tools:
+  # ANNOTATION
   - name: abricate
     owner: iuc
     tool_panel_section_label: Annotation
@@ -5740,4 +5745,3 @@
   - name: gem_check_memote
     owner: iuc
     tool_panel_section_label: Metabolomics
-


### PR DESCRIPTION
This PR adds the FBQS Integrator (fbqs_integrator) definition to diverse.yaml.  
FBQS Integrator merges quality-checked Fastp, Bracken and QUAST outputs into a unified STARAMR Excel report,  
including automatic QC flags (Passed/Warning/Fail) and separate sheets for Fastp, Bracken, Quast and overall quality metrics.

Contributors:
- Elena Lavinia Diaconu (elena.diaconu@izslt.it)
- Maciej Kochanowski (maciej.kochanowski@piwet.pulawy.pl)
- Sebastien Leclercq (sebastien.leclercq@inrae.fr)

Tool metadata:
- name: fbqs_integrator
- owner: SPAMR-VET Consortium (EUPAHW)



