### PR TITLE
Add PHAC-NML quasitools

### DIFF
--- a/nml.yaml
+++ b/nml.yaml
@@ -23,3 +23,43 @@ tools:
   - name: 'collapse_collections'
     owner: 'nml'
     tool_panel_section_label: 'Collection Operations'
+
+  - name: 'aacoverage'
+    owner: 'nml'
+    tool_panel_section_label: 'Quasitools'
+
+  - name: 'callaavar'
+    owner: 'nml'
+    tool_panel_section_label: 'Quasitools'
+
+  - name: 'callcodonvar'
+    owner: 'nml'
+    tool_panel_section_label: 'Quasitools'
+
+  - name: 'callntvar'
+    owner: 'nml'
+    tool_panel_section_label: 'Quasitools'
+
+  - name: 'complexity_bam'
+    owner: 'nml'
+    tool_panel_section_label: 'Quasitools'
+
+  - name: 'complexity_fasta'
+    owner: 'nml'
+    tool_panel_section_label: 'Quasitools'
+
+  - name: 'consensus'
+    owner: 'nml'
+    tool_panel_section_label: 'Quasitools'
+
+  - name: 'distance'
+    owner: 'nml'
+    tool_panel_section_label: 'Quasitools'
+
+  - name: 'drmutations'
+    owner: 'nml'
+    tool_panel_section_label: 'Quasitools'
+
+  - name: 'hydra'
+    owner: 'nml'
+    tool_panel_section_label: 'Quasitools'


### PR DESCRIPTION
This adds some of the commands of PHAC-NML's quasitools, using these wrappers: https://github.com/phac-nml/galaxy_tools/tree/master/tools/quasitools. These tools are typically used for analysing HIV data.