### PR TITLE
Add new source for sortmerna

### DIFF
--- a/bgruening.yaml
+++ b/bgruening.yaml
@@ -103,7 +103,7 @@ tools:
     tool_panel_section_label: Annotation
 
   - name: sortmerna
-    owner: bgruening
+    owner: rnateam
     tool_panel_section_label: Annotation
 
 # ASSEMBLY

--- a/bgruening.yaml
+++ b/bgruening.yaml
@@ -102,6 +102,10 @@ tools:
     owner: bgruening
     tool_panel_section_label: Annotation
 
+  - name: sortmerna
+    owner: bgruening
+    tool_panel_section_label: Annotation
+
 # ASSEMBLY
 
   - name: blobtoolkit


### PR DESCRIPTION
The current deployed wrapper is from the RNA team https://github.com/usegalaxy-eu/usegalaxy-eu-tools/blob/4c07177dcae7287eacd85fe4bcc7d7dbfc24c510/europe-custom.yaml#L865-L867
Which is on a very old (2.1b.6) and buggy version of the tool.
The new wrapper uses 4.3.6.
I am not sure if the entry for the old wrapper should be removed ? Will that also remove the tool from the server ? If not how can the new one succeed the old one ?  Ideally, we keep the old versions, since it will break some workflow otherwise. 