### PR TITLE
Add Sequali as a quality control tool

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -3822,6 +3822,10 @@ tools:
     owner: iuc
     tool_panel_section_label: Quality Control
 
+  - name: sequali
+    owner: iuc
+    tool_panel_section_label: Quality Control
+
 
 # RAD-SEQ
 


### PR DESCRIPTION
Sequali is a FastQC/NanoPlot replacement which is very comprehensive and fast.

Sequali was written to support both Illumina+FASTQ and ONT+FASTQ/uBAM work loads. It also works well for PacBio. 

For more information see: https://github.com/rhpvorderman/sequali/

I also recommend reading the paper: https://academic.oup.com/bioinformaticsadvances/article/5/1/vbaf010/7989317?login=false 

Disclaimer: I wrote Sequali. Mostly to fill the gaps that other tools left wide open, and because I want my QC reports to come in as quickly as possible. 

I chose the Quality Control section. I could have placed it in "Nanopore" but it also works for Illumina. I could have placed it in "FASTQ/FASTQ" but it also works on uBAM. If there is a better section, I am happy to update the PR.