### PR TITLE
Added dos2unix tool for text cleaning of DH tutorial on GTN.

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -4761,6 +4761,10 @@ tools:
     owner: iuc
     tool_panel_section_label: Text Manipulation
 
+  - name: dos2unix
+    owner: iuc
+    tool_panel_section_label: Text Manipulation
+
   - name: coverage
     owner: devteam
     tool_panel_section_label: Text Manipulation


### PR DESCRIPTION
I added the dos2unix tool that can be used for text cleaning in the following GTN tutorial (workflow): https://training.galaxyproject.org/topics/statistics/tutorials/text_mining_chinese/tutorial.html