### PR TITLE
add map_damage to tools_iuc.yaml

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -996,6 +996,10 @@ tools:
     owner: iuc
     tool_panel_section_label: Evolution
 
+  - name: map_damage
+    owner: iuc
+    tool_panel_section_label: Evolution
+
   - name: mutate_snp_codon
     owner: devteam
     tool_panel_section_label: Evolution


### PR DESCRIPTION
Hello !

I'd like to add the recently wrapped mapDamage tool to Galaxy EU ([tools-iuc PR here](https://github.com/galaxyproject/tools-iuc/pull/7081))

I've put it under the evolution section, let me know if that seems fine

Thanks!