### PR TITLE
Add MetaSBT suite

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -2893,6 +2893,14 @@ tools:
     owner: iuc
     tool_panel_section_label: Metagenomic Analysis
 
+  - name: metasbt_index
+    owner: iuc
+    tool_panel_section_label: Metagenomic Analysis
+
+  - name: metasbt_profile
+    owner: iuc
+    tool_panel_section_label: Metagenomic Analysis
+
 # MOTHUR
 
   - name: mothur_align_check

--- a/tools_iuc.yaml.lock
+++ b/tools_iuc.yaml.lock
@@ -6762,6 +6762,16 @@ tools:
   - 6150c3b0a1eb
   - ee32f1a3b2a7
   tool_panel_section_label: Metagenomic Analysis
+- name: metasbt_index
+  owner: iuc
+  revisions:
+  - dff5f0dd17eb
+  tool_panel_section_label: Metagenomic Analysis
+- name: metasbt_profile
+  owner: iuc
+  revisions:
+  - 14515a211bd9
+  tool_panel_section_label: Metagenomic Analysis
 - name: mothur_align_check
   owner: iuc
   revisions:


### PR DESCRIPTION
Add MetaSBT suite (`metasbt_index` and `metasbt_profile`) to the Metagenomic Analysis section.
https://github.com/galaxyproject/tools-iuc/pull/7141