### PR TITLE
Update ecology.yaml add yolo tools in Computer Vision Ecology section

### DIFF
--- a/ecology.yaml
+++ b/ecology.yaml
@@ -1014,3 +1014,19 @@ tools:
   - name: population_genomics_split_vcf_by_pop
     owner: ecology
     tool_panel_section_label: 'Population Genomics'
+    
+  - name: doclayoutyolo
+    owner: bgruening
+    tool_panel_section_label: 'Computer Vision'
+    
+  - name: yolo_training
+    owner: bgruening
+    tool_panel_section_label: 'Computer Vision'
+    
+  - name: yolo_predict
+    owner: bgruening
+    tool_panel_section_label: 'Computer Vision'
+
+  - name: json2yolosegment
+    owner: bgruening
+    tool_panel_section_label: 'Computer Vision'


### PR DESCRIPTION
As it seems to me better to do so to have yolo tools on ecology subdomain instead of "loading" the "Imaging" section.