### PR TITLE
Add rag_retriever tool

### DIFF
--- a/bgruening.yaml
+++ b/bgruening.yaml
@@ -459,6 +459,10 @@ tools:
     owner: bgruening
     tool_panel_section_label: Machine Learning
 
+  - name: rag_retriever
+    owner: bgruening
+    tool_panel_section_label: Machine Learning
+
   - name: black_forest_labs_flux
     owner: bgruening
     tool_panel_section_label: Machine Learning

--- a/bgruening.yaml.lock
+++ b/bgruening.yaml.lock
@@ -992,6 +992,11 @@ tools:
   - 914a7b992c2c
   - 99898a312165
   tool_panel_section_label: Machine Learning
+- name: rag_retriever
+  owner: bgruening
+  revisions:
+  - 733bde6b986b
+  tool_panel_section_label: Machine Learning
 - name: black_forest_labs_flux
   owner: bgruening
   revisions:


### PR DESCRIPTION
Adds \`rag_retriever\` by \`bgruening\` to the Machine Learning section.

**Toolshed:** https://toolshed.g2.bx.psu.edu/repositories/a84309af4a9c64c6

Implements the retrieval step of a Retrieval-Augmented Generation (RAG) pipeline — loads Galaxy datasets, creates HuggingFace embeddings, returns relevant text chunks for downstream LLM tools. Supports CUDA with CPU fallback.

**Note:** A `huggingface.loc` file also needs to be added as described in usegalaxy-eu/infrastructure-playbook#2008.

Embedding models can be pre-downloaded using the provided script: https://github.com/bgruening/galaxytools/blob/master/tools/rag/download_embeddings.py