### PR TITLE
Add protein_mosaic_q: Mosaic Q structural descriptor and 3D visualisation

### DIFF
--- a/diverse.yaml
+++ b/diverse.yaml
@@ -71,3 +71,8 @@ tools:
   - name: data_manager_defense_finder
     owner: rplanel
     tool_panel_section_label: Metagenomic Analysis
+
+  - name: protein_mosaic_q
+    owner: fjlobocab
+    tool_panel_section_label: Proteomics
+    

--- a/diverse.yaml.lock
+++ b/diverse.yaml.lock
@@ -87,3 +87,8 @@ tools:
   revisions:
   - 502208b90cfe
   tool_panel_section_label: Metagenomic Analysis
+- name: protein_mosaic_q
+  owner: fjlobocab
+  revisions:
+  - c9de311a8aeb
+  tool_panel_section_label: Proteomics


### PR DESCRIPTION
## Tool installation request

**Tool Shed repository:** 
https://toolshed.g2.bx.psu.edu/view/fjlobocab/protein_mosaic_q

**Description:** 
Proteins Mosaic Q i) calculates the Q and Q_alt structural descriptors for protein structures from the PDB and ii) renders an interactive 3D visualisation coloured by amino acid chemical family (polar, acidic, basic, special, hydrophobic) using 3Dmol.js. The visualisation allows users to directly appreciate the proposed Mosaic Q pattern feature.

**Dependencies:** 
- Python >=3.9, single dependency (biopython)

**Software registries:**
- bio.tools: https://bio.tools/protein-mosaic-q
- Bioconda: https://anaconda.org/bioconda/protein-mosaic-q

**Scientific context:**
- FAIRsharing: https://fairsharing.org/8206
- Preprint: https://doi.org/10.1101/500025
- Updated manuscript: https://github.com/UPO-Sevilla-Fco-Javier-Lobo-Cabrera/clustering_trait_proteins/blob/main/Manuscript_and_Supplementary_Materials_v4.pdf
- Project website: https://proteins-mosaic-q.org
- SciStarter: https://scistarter.org/proteins-mosaic-q-project
- EU Citizen Science: https://citizenscience.eu/project/686

**Suggested panel section:** Proteomics