### PR TITLE
fix(sync): only advance sync SHA pointer when new tools are added

### DIFF
--- a/scripts/sync-tools-repo.py
+++ b/scripts/sync-tools-repo.py
@@ -1029,8 +1029,10 @@ Important:
                     file=sys.stderr,
                 )
 
-        # Advance the SHA pointer (same commit as YAML changes)
-        if self._pending_new_sha and self.last_sync_sha_file is not None:
+        # Only advance the sync pointer when this run actually adds tools.
+        # Otherwise we would generate a SHA-only PR and stop reconsidering the
+        # same source changes on later runs.
+        if self.new_tools and self._pending_new_sha and self.last_sync_sha_file is not None:
             if not self.dry_run:
                 self.last_sync_sha_file.write_text(self._pending_new_sha + "\n")
                 print(


### PR DESCRIPTION
This PR fixes the issue where the tools-sync workflow creates empty/SHA-only Pull Requests containing no new tools (as described in https://github.com/usegalaxy-eu/usegalaxy-eu-tools/pull/1034#issuecomment-4459803973).

By only updating/writing the 'last_sync_sha_file' when new tools are actually found (i.e. 'self.new_tools' is non-empty), we avoid generating unnecessary commits and empty PRs, and ensure that the script will re-evaluate the same source commits in subsequent runs until actual tool updates are processed.