### PR TITLE
Fix bug in fix-lockfile.py preventing new tools from being added

### DIFF
--- a/scripts/fix-lockfile.py
+++ b/scripts/fix-lockfile.py
@@ -25,7 +25,7 @@ def update_file(fn, dry):
         locked_tools = [x for x in locked['tools'] if x['name'] == tool['name'] and x['owner'] == tool['owner']]
         # If there are no copies of it seen in the lockfile, we'll just copy it
         # over directly, without a reivision. Another script will fix that.
-        if len(locked) == 0:
+        if len(locked_tools) == 0:
             # new tool, just add directly.
             clean_lockfile['tools'].append(tool)
             continue


### PR DESCRIPTION
Fixes line 28 which checked `if len(locked) == 0:` instead of `if len(locked_tools) == 0:`.

This caused new tools to be silently skipped from the lock file, preventing them from being installed on usegalaxy.eu.

Fixes CI lint failure: https://github.com/usegalaxy-eu/usegalaxy-eu-tools/actions/runs/26823713956/job/79085108349