### PR TITLE
Fix rate limiting in fix-outdated-tools workflow

### DIFF
--- a/.github/workflows/fix-outdated-tools.yml
+++ b/.github/workflows/fix-outdated-tools.yml
@@ -26,6 +26,7 @@ jobs:
     strategy:
       matrix:
         lockfile: ${{ fromJson(needs.get-lockfiles.outputs.lockfiles) }}
+      max-parallel: 4
       fail-fast: false
     permissions:
       contents: write

--- a/scripts/fix_outdated.py
+++ b/scripts/fix_outdated.py
@@ -106,11 +106,12 @@ def fix_uninstallable(lockfile_name, toolshed_url):
                 f"Progress: {i}/{total} tools ({skipped} skipped, {changed} changed)"
             )
 
+        # Brief pause every 50 requests to avoid overwhelming the server
+        if i > 0 and i % 50 == 0:
+            time.sleep(1)
+
         name, owner = tool.get("name"), tool.get("owner")
         current_revisions = set(tool.get("revisions", []))
-
-        # Add delay between requests to avoid rate limiting
-        time.sleep(0.5)
 
         try:
             installable_list = retry_with_backoff(

--- a/scripts/fix_outdated.py
+++ b/scripts/fix_outdated.py
@@ -24,15 +24,18 @@ def retry_with_backoff(func, *args, **kwargs):
             return func(*args, **kwargs)
         except Exception as e:
             error_msg = str(e)
+            # Check for rate limiting (429) or server errors
             if any(
                 code in error_msg
-                for code in ["502", "503", "504", "timed out", "timeout", "Connection"]
+                for code in ["429", "502", "503", "504", "timed out", "timeout", "Connection"]
             ):
                 if attempt < max_retries - 1:
+                    # Use longer backoff for rate limiting
+                    wait_time = 5 if "429" in error_msg else backoff
                     logger.warning(
-                        f"Attempt {attempt + 1}/{max_retries} failed: {error_msg}. Retrying in {backoff}s..."
+                        f"Attempt {attempt + 1}/{max_retries} failed: {error_msg}. Retrying in {wait_time}s..."
                     )
-                    time.sleep(backoff)
+                    time.sleep(wait_time)
                     backoff = min(backoff * 2, 60)
                     continue
             raise e
@@ -56,7 +59,7 @@ def get_tool_versions(ts, name, owner, revision):
     return versions
 
 
-def fetch_versions_parallel(ts, name, owner, revisions, max_workers=10):
+def fetch_versions_parallel(ts, name, owner, revisions, max_workers=3):
     version_cache = {}
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = {
@@ -105,6 +108,10 @@ def fix_uninstallable(lockfile_name, toolshed_url):
 
         name, owner = tool.get("name"), tool.get("owner")
         current_revisions = set(tool.get("revisions", []))
+
+        # Add delay between requests to avoid rate limiting
+        time.sleep(0.5)
+
         try:
             installable_list = retry_with_backoff(
                 ts.repositories.get_ordered_installable_revisions, name, owner


### PR DESCRIPTION
Fixes HTTP 429 errors from Galaxy Toolshed by:
- Adding 429 to retry codes with 5s initial backoff
- Reducing thread pool workers from 10 to 3
- Adding 0.5s delay between tool requests
- Limiting matrix concurrency to 4 jobs