### PR TITLE
Harden GitHub Actions workflows with zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 30

--- a/.github/workflows/fix-outdated-tools.yml
+++ b/.github/workflows/fix-outdated-tools.yml
@@ -5,6 +5,8 @@ on:
   schedule:
     - cron: '0 9 1 * *'
 
+permissions: {}
+
 jobs:
   get-lockfiles:
     runs-on: ubuntu-latest
@@ -13,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Get all lock files
         id: set-matrix
@@ -33,6 +37,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -48,7 +54,9 @@ jobs:
         run: uv pip install --system -r requirements.txt
 
       - name: Fix ${{ matrix.lockfile }}
-        run: python scripts/fix_outdated.py "${{ matrix.lockfile }}"
+        run: python scripts/fix_outdated.py "${MATRIX_LOCKFILE}"
+        env:
+          MATRIX_LOCKFILE: ${{ matrix.lockfile }}
 
       - name: Get base name
         id: basename
@@ -78,6 +86,7 @@ jobs:
         uses: actions/checkout@v5
         with:
             fetch-depth: 0
+            persist-credentials: false
 
       - name: Download all artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,6 +18,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -35,6 +35,8 @@ jobs:
           architecture: 'x64'
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Install pyyaml

--- a/.github/workflows/sync-tools.yml
+++ b/.github/workflows/sync-tools.yml
@@ -14,6 +14,8 @@ on:
   schedule:
     - cron: '0 8 * * 5'  # Every Friday 08:00 UTC
 
+permissions: {}
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -44,16 +46,21 @@ jobs:
       - name: Set run flag
         id: gate
         run: |
-          if [[ -z "${{ steps.check_pr.outputs.number }}" || "${{ github.event.inputs.force }}" == "true" ]]; then
+          if [[ -z "${STEPS_CHECK_PR_OUTPUTS_NUMBER}" || "${GITHUB_EVENT_INPUTS_FORCE}" == "true" ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
           else
-            echo "Skipping ${{ matrix.name }}: PR #${{ steps.check_pr.outputs.number }} already open."
+            echo "Skipping ${{ matrix.name }}: PR #${STEPS_CHECK_PR_OUTPUTS_NUMBER} already open."
             echo "should_run=false" >> $GITHUB_OUTPUT
           fi
+        env:
+          STEPS_CHECK_PR_OUTPUTS_NUMBER: ${{ steps.check_pr.outputs.number }}
+          GITHUB_EVENT_INPUTS_FORCE: ${{ github.event.inputs.force }}
 
       - name: Checkout repository
         if: steps.gate.outputs.should_run == 'true'
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         if: steps.gate.outputs.should_run == 'true'
@@ -76,6 +83,7 @@ jobs:
           repository: ${{ matrix.source_repo }}
           path: ${{ matrix.name }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run sync script
         if: steps.gate.outputs.should_run == 'true'

--- a/.github/workflows/update-trusted.yml
+++ b/.github/workflows/update-trusted.yml
@@ -7,6 +7,8 @@ on:
     - cron:  '0 23 * * 6'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,6 +19,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,6 +2,8 @@ name: GitHub Actions Security Analysis with zizmor
 
 on:
   push:
+    branches:
+      - master
     paths:
       - '.github/workflows/*'
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -25,3 +25,5 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          advanced-security: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,27 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    paths:
+      - '.github/workflows/*'
+  pull_request:
+    paths:
+      - '.github/workflows/*'
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        '*': ref-pin


### PR DESCRIPTION
Apply zizmor security best practices to all workflows.

See https://docs.zizmor.sh/

Also:
- Run zizmor-action on changes to GitHub workflows
- Monthly dependabot for GitHub Actions updates