### PR TITLE
fix(ci): grant update-trusted workflow write permission

### DIFF
--- a/.github/workflows/update-trusted.yml
+++ b/.github/workflows/update-trusted.yml
@@ -12,6 +12,8 @@ permissions: {}
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     strategy:
       matrix:
         python-version: [3.11]


### PR DESCRIPTION
## Summary
- add job-level `permissions: contents: write` to `.github/workflows/update-trusted.yml`
- allow the workflow to push updates back to `master`

## Why
Issue #1061 reports a failure in `Update Trusted Tools`:
- `github-actions[bot]` fails to push with `403` due to missing write permission

This change addresses that second failure.

Closes #1061