### PR TITLE
Trigger update-trusted workflow on push of *.yaml files to master

### DIFF
--- a/.github/workflows/update-trusted.yml
+++ b/.github/workflows/update-trusted.yml
@@ -6,6 +6,11 @@ on:
     # We'll run this weekly at 23.00 on Saturday.
     - cron:  '0 23 * * 6'
   workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - '*.yaml'
 
 permissions: {}
 


### PR DESCRIPTION
This PR triggers the `update-trusted` workflow whenever `*.yaml` files are pushed to the `master` branch. Related to https://github.com/usegalaxy-eu/usegalaxy-eu-tools/pull/1043#issuecomment-4614361521