### PR TITLE
Add MAGs-visualization tools to the Metagenomic Analysis section

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -3733,6 +3733,30 @@ tools:
   - name: kmindex
     owner: iuc
     tool_panel_section_label: Metagenomic Analysis
+  
+  - name: mags_visualization_comp_conta
+    owner: iuc
+    tool_panel_section_label: Metagenomic Analysis
+  
+  - name: mags_visualization_drep_cluster_annot
+    owner: iuc
+    tool_panel_section_label: Metagenomic Analysis
+  
+  - name: mags_visualization_drep_cluster_func
+    owner: iuc
+    tool_panel_section_label: Metagenomic Analysis
+  
+  - name: mags_visualization_pathway_module_heatmap
+    owner: iuc
+    tool_panel_section_label: Metagenomic Analysis
+  
+  - name: mags_visualization_sample_heatmap
+    owner: iuc
+    tool_panel_section_label: Metagenomic Analysis
+  
+  - name: mags_visualization_taxa_sankey
+    owner: iuc
+    tool_panel_section_label: Metagenomic Analysis
 
 # MOTHUR
 


### PR DESCRIPTION
Add 6 MAGs-visualization tools to the Metagenomic Analysis section.

Tools added:
- mags_visualization_comp_conta
- mags_visualization_drep_cluster_annot
- mags_visualization_drep_cluster_func
- mags_visualization_pathway_module_heatmap
- mags_visualization_sample_heatmap
- mags_visualization_taxa_sankey

These tools are available in tools-iuc: https://github.com/galaxyproject/tools-iuc/tree/main/tools/mags_visualization