### PR TITLE
Update fbqs_integrator to 8132630e5e02

### DIFF
--- a/diverse.yaml.lock
+++ b/diverse.yaml.lock
@@ -55,6 +55,7 @@ tools:
 - name: fbqs_integrator
   owner: maciek
   revisions:
+  - 8132630e5e02
   - 9cadfa80fc35
   tool_panel_section_label: Assembly
 - name: ncbi_egapx


### PR DESCRIPTION
## Summary

Adds the latest installable Tool Shed revision of
`maciek/fbqs_integrator` to Galaxy Europe.

## Revisions

- Existing revision retained: `9cadfa80fc35`
- New installable revision: `8132630e5e02`
- Expected Galaxy tool version: `1.0.1`

## Scope

- Updated only `diverse.yaml.lock`
- No changes to `diverse.yaml`
- No unrelated tool revisions modified
- Previous revision retained for workflow reproducibility

## Validation

- Tool Shed installable revisions queried through BioBlend
- `pykwalify -d diverse.yaml -s .schema.yaml`: PASS
- `python scripts/identify-unpinned.py diverse.yaml`: PASS
- `python scripts/pr-check.py diverse.yaml`: PASS
- Targeted YAML and revision assertions: PASS
- `git diff --check`: PASS
