### PR TITLE
Add add_input_name_as_column tool to Text Manipulation

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -6664,6 +6664,10 @@ tools:
     owner: devteam
     tool_panel_section_label: Text Manipulation
 
+  - name: add_input_name_as_column
+    owner: mvdbeek
+    tool_panel_section_label: Text Manipulation
+
   - name: column_order_header_sort
     owner: iuc
     tool_panel_section_label: Text Manipulation


### PR DESCRIPTION
@arash77 I think this was not added because it has a  different owner than IUC? Can this be? However, it is now part of IUC. This can happen when tools are moved later to IUC, so IUC 'adopts' those tools and maintains them.

Can you bot also catch those?

Or is there a different reason this tool is not added?