### PR TITLE
Update metabolomics.yaml to modify tool entries CAMERA tools

### DIFF
--- a/metabolomics.yaml
+++ b/metabolomics.yaml
@@ -41,11 +41,27 @@ tools:
     owner: lecorguille
     tool_panel_section_label: Metabolomics
 
-  - name: camera_annotate
+  - name: xcms_summary
     owner: lecorguille
     tool_panel_section_label: Metabolomics
-
-  - name: xcms_summary
+    
+  - name: camera_groupfwhm
+    owner: workflow4metabolomics
+    tool_panel_section_label: Metabolomics
+    
+  - name: camera_groupcorr
+    owner: workflow4metabolomics
+    tool_panel_section_label: Metabolomics
+    
+  - name: camera_findisotopes
+    owner: workflow4metabolomics
+    tool_panel_section_label: Metabolomics
+    
+  - name: camera_findadducts
+    owner: workflow4metabolomics
+    tool_panel_section_label: Metabolomics
+  
+  - name: camera_annotate
     owner: lecorguille
     tool_panel_section_label: Metabolomics
 


### PR DESCRIPTION
Dear Maintainers,

The `CAMERA.annotate `wrapper currently provides a one-step execution of several functions from the CAMERA package. This PR enables users to run each of these functions independently (camera.fwhm --> camera.findisotope --> camera.findaddcuts...), providing greater flexibility in designing and customizing annotation workflows.

Best regards,
Yann