### PR TITLE
Skip repository_suite_definition metapackages in sync bot

### DIFF
--- a/scripts/sync-tools-repo.py
+++ b/scripts/sync-tools-repo.py
@@ -164,6 +164,16 @@ class ToolsRepoSyncer:
             if not owner:
                 return None
 
+            # Skip suite-definition metapackages: a top-level type ==
+            # 'repository_suite_definition' ships only a repository_dependencies.xml
+            # referencing other repos and installs nothing itself (those tools sync
+            # from their own .shed.yml). Check the top-level 'type', NOT a sibling
+            # repository_dependencies.xml — real tools (e.g. bgruening tools/openms)
+            # also carry one for extra deps, and a nested 'suite:' block can itself
+            # be a suite definition; neither makes the repo a metapackage.
+            if data.get("type") == "repository_suite_definition":
+                return None
+
             # Handle auto_tool_repositories (suite tools like bcftools).
             # These .shed.yml files often have no top-level 'name' field, so we
             # must check for auto_tool_repositories BEFORE the 'if not name' guard.


### PR DESCRIPTION
## What & why

The sync bot added `suite_fasta_tools` (a suite **metapackage**, not a tool) to `tools_iuc.yaml` in #1101. Per @bgruening's [comment](https://github.com/usegalaxy-eu/usegalaxy-eu-tools/pull/1101#discussion_r3676522891), suite metapackages should never be added — we want individual repos listed explicitly.

A `.shed.yml` whose top-level `type` is `repository_suite_definition` ships only a `repository_dependencies.xml` referencing other repos and installs nothing itself. The individual tools it points to are synced from their own source repos, so the metapackage adds no coverage and should never enter the yaml.

## Change

In `parse_shed_yml`, return `None` early when `data.get("type") == "repository_suite_definition"` — a silent, deterministic structural filter, mirroring the existing `"deprecated" in path.parts` skip in `scan_source_repo`.

## Why `type`, not a sibling `repository_dependencies.xml`

An earlier draft checked for a sibling `repository_dependencies.xml`, but that **falsely skips real tools**: bgruening `tools/openms` (and `molecule2gspan`, `miRDeep2`) carry a `repository_dependencies.xml` for *extra dependency repos* while being `type: unrestricted` tools that ship real tool XMLs. The top-level `type` field is the reliable signal — only true metapackages declare it.

Tools with `auto_tool_repositories` (bcftools/cat/cnvkit) nest a `suite:` block whose own `type` is `repository_suite_definition`, but their **top-level** `type` is `unrestricted` (or absent), so `data.get("type")` does not see the nested value and they are unaffected.

## Verification

Tested `parse_shed_yml` against real `.shed.yml` files from both source repos:

| Case | Expected | Result |
|------|----------|--------|
| `suite_fasta_tools` (iuc, top-level `type: repository_suite_definition`) | skip | skipped ✅ |
| `tools/openms` (bg, real tool + sibling `repository_dependencies.xml`, `type: unrestricted`) | keep | kept ✅ |
| `tools/molecule2gspan` (bg, same pattern) | keep | kept ✅ |
| `tools/cat` (iuc, `auto_tool_repositories` + nested `suite:` block) | keep, expand to sub-tools | 5 tool repos ✅ |
| `tools/cnvkit` (iuc, no top-level `type`, nested `suite:` block) | keep, expand to sub-tools | 25 tool repos ✅ |

Full scan of both repos confirms `suite_fasta_tools` is the only non-deprecated `repository_suite_definition` in either source — zero false-positive risk against any real tool.

## Note on #1101

#1101 has merged; `suite_fasta_tools` was dropped before/during merge and is **not** in `master`. This PR (#1102) is the prevention fix — without it, the next catchup sync would re-propose the same metapackage, since its `.shed.yml` still exists in tools-iuc.
