### PR TITLE
Add deacon

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -2030,6 +2030,10 @@ tools:
     owner: iuc
     tool_panel_section_label: FASTA/FASTQ
 
+  - name: deacon
+    owner: iuc
+    tool_panel_section_label: FASTA/FASTQ
+
 # FILTER AND SORT
 
   - name: gffcompare


### PR DESCRIPTION
This adds the [deacon](https://github.com/bede/deacon) tools for filtering and de-hosting reads. Wrappers were recently [added to tools-iuc](https://github.com/galaxyproject/tools-iuc/pull/8247).

(I am not clear if the individual tools need to get mentioned or if they'll all be pulled in by the mention of deacon)