### PR TITLE
Add 'earthdata_api' to ecology.yaml

### DIFF
--- a/ecology.yaml
+++ b/ecology.yaml
@@ -778,6 +778,10 @@ tools:
   - name: copernicusmarine
     owner: ecology
     tool_panel_section_label: 'Get Data'    
+
+  - name: earthdata_api
+    owner: ecology
+    tool_panel_section_label: 'Get Data'
     
   - name: dwt_var_perfeature
     owner: devteam


### PR DESCRIPTION
Hello,
This PR adds a tool that fetches NASA environmental data from Earthdata using the `earthaccess` API.
