### PR TITLE
Show new tools inline and collapse removed revisions in the weekly PR body

### DIFF
--- a/.github/workflows/weekly-tools-update.yml
+++ b/.github/workflows/weekly-tools-update.yml
@@ -340,15 +340,19 @@ jobs:
             echo "Synced from \`galaxyproject/tools-iuc\` and \`bgruening/galaxytools\`."
             echo ""
             if [ "$new_tools" -gt 0 ] && ls sync-report-*.md >/dev/null 2>&1; then
+              # New tools are the part reviewers actually read, so they are inlined
+              # rather than collapsed. The per-report H1 and the workflow footer are
+              # dropped and the report's own H2s demoted, so each report nests cleanly
+              # under this section instead of restarting the heading hierarchy.
               for f in sync-report-*.md; do
                 name="${f#sync-report-}"
                 name="${name%.md}"
-                echo "<details>"
-                echo "<summary>Sync report: ${name}</summary>"
-                echo ""
-                cat "$f"
-                echo ""
-                echo "</details>"
+                echo "### Sync report: ${name}"
+                # No blank line here: dropping the report's H1 leaves one in its place.
+                sed -e '/^# Tools Sync Report$/d' \
+                    -e 's/^## /#### /' \
+                    -e '/^---$/d' \
+                    -e '/^🤖 This PR was automatically generated/d' "$f"
                 echo ""
               done
             else
@@ -370,6 +374,11 @@ jobs:
             echo "These revisions are no longer installable from the ToolShed and were dropped from the lockfiles (recorded in \`not-installable-revisions/\`)."
             echo ""
             if [ "$removed_revs" -gt 0 ] && ls not-installable-revisions/*.not-installable-revisions.yaml >/dev/null 2>&1; then
+              # This table can run to dozens of rows and is rarely acted on, so it is
+              # collapsed by default to keep the new tools above it visible.
+              echo "<details>"
+              echo "<summary>Show ${removed_revs} removed $(plural "$removed_revs" revision)</summary>"
+              echo ""
               echo "| Tool | Owner | Removed revision(s) |"
               echo "| :--- | :--- | :--- |"
               # Revisions added to the append-only not-installable files this run are the
@@ -389,6 +398,8 @@ jobs:
                   print "| `" name "` | `" owner "` | `" rev "` |"
                 }
               '
+              echo ""
+              echo "</details>"
             else
               echo "_None this run._"
             fi


### PR DESCRIPTION
Follow-up to @bgruening's comment on #1113:

> > Removed not-installable revisions
>
> should be hidden and the new tools should be shown I guess?

The weekly PR body currently does the opposite: the sync reports are tucked into a collapsed `<details>`, while the removed-revisions table is dumped inline — in #1113 that was 71 rows pushing everything else off screen.

This swaps the two:

- **New tools** are inlined under a `### Sync report: <name>` heading. Each report's own `# Tools Sync Report` H1, trailing `---`, and redundant "🤖 automatically generated by the `sync-tools-repo` workflow" footer are stripped, and its `##` headings demoted to `####`, so the reports nest under the PR body's sections instead of restarting the heading hierarchy.
- **Removed not-installable revisions** keeps its heading and explanatory sentence visible, but the table itself moves into `<details><summary>Show N removed revisions</summary>`.

Only the PR body formatting changes; no change to what is synced, updated, or deprecated.