### PR TITLE
Added 3dbeacons_api as new tool in proteomics

### DIFF
--- a/tools_iuc.yaml
+++ b/tools_iuc.yaml
@@ -5521,6 +5521,10 @@ tools:
 
 # PROTEOMICS
 
+  - name: 3dbeacons_api
+    owner: iuc
+    tool_panel_section_label: Proteomics
+
   - name: colabfold_msa
     owner: iuc
     tool_panel_section_label: Proteomics


### PR DESCRIPTION
Adds the 3dbeacons_api tool integration to tools_iuc.yaml in the Proteomics section.