### PR TITLE
Add GlyCombo tool

### DIFF
--- a/diverse.yaml
+++ b/diverse.yaml
@@ -23,6 +23,10 @@ tools:
   - name: bioconductor_scp
     owner: recetox
     tool_panel_section_label: Proteomics
+    
+  - name: glycombo
+    owner: proteaglycosciences
+    tool_panel_section_label: Proteomics
 
   - name: table_pandas_arithmetics
     owner: recetox


### PR DESCRIPTION
Adds GlyCombo to UseGalaxy.eu under the Proteomics tool panel.

GlyCombo is an open-source glycan composition assignment tool for text mass lists and mzML files (https://pubmed.ncbi.nlm.nih.gov/39271475/) and this is the CLI version of that tool (https://www.biorxiv.org/content/10.64898/2026.05.13.725058v2.full).

The Galaxy wrapper is available from the Main Galaxy Tool Shed:
proteaglycosciences/glycombo

Current tool version:
1.0.0+galaxy1

The wrapper contains 21 embedded Galaxy functional tests and is tested against the versioned GlyComboCLI Docker container using Planemo and GitHub Actions.

An earlier version of GlyCombo is also currently deployed on Galaxy Australia, with the version update to be implemented soon.

Galaxy wrapper source:
https://github.com/Protea-Glycosciences/GlyComboGalaxy

CLI source:
[https://github.com/Protea-Glycosciences/GlyComboCLI](https://github.com/Protea-Glycosciences/GlyComboCLI)