### PR TITLE
Add mirtrace_qc and mirtrace_trace tools

### DIFF
--- a/bgruening.yaml
+++ b/bgruening.yaml
@@ -71,6 +71,14 @@ tools:
     owner: bgruening
     tool_panel_section_label: RNA Analysis
 
+  - name: mirtrace_qc
+    owner: bgruening
+    tool_panel_section_label: RNA Analysis
+
+  - name: mirtrace_trace
+    owner: bgruening
+    tool_panel_section_label: RNA Analysis
+
 # SAM/BAM
 
   - name: sambamba_flagstat


### PR DESCRIPTION
I don't know exactly why they were not caught in the auto update workflow. Maybe because I initally added wrong owner in the .shed.yml