### PR TITLE
Add langchain_text_splitters tool to Digital Humanities section in bgruening.yaml

### DIFF
--- a/bgruening.yaml
+++ b/bgruening.yaml
@@ -255,6 +255,10 @@ tools:
     owner: bgruening
     tool_panel_section_label: Digital Humanities
 
+  - name: langchain_text_splitters
+    owner: bgruening
+    tool_panel_section_label: Digital Humanities
+
 
 # FASTA/FASTQ
 


### PR DESCRIPTION
Corresponding merged PR:
https://github.com/bgruening/galaxytools/pull/1947